### PR TITLE
Table init method correctly supports create option.

### DIFF
--- a/lib/Table.js
+++ b/lib/Table.js
@@ -19,20 +19,24 @@ function Table(name, schema, options, base) {
 
 Table.prototype.init = function(next) {
   debug('initializing table', this);
-  this.describe(function (err) {
-    if(err && err.code === 'ResourceNotFoundException' && this.options.create) {
-      debug('table does not exist -- creating');
-      return this.create(next);
-    }
-    if(err) {
-      debug('error initializing', err);
-      return next(err);
-    }
+  if (this.options.create) {
+    this.describe(function (err) {
+      if(err && err.code === 'ResourceNotFoundException') {
+        debug('table does not exist -- creating');
+        return this.create(next);
+      }
+      if(err) {
+        debug('error initializing', err);
+        return next(err);
+      }
 
-    debug('table exist -- initialization done');
-    // TODO verify table keys and index's match
-    return next();
-  }.bind(this));
+      debug('table exist -- initialization done');
+      // TODO verify table keys and index's match
+      return next();
+    }.bind(this));
+  } else {
+    next();
+  }
 };
 
 Table.prototype.describe = function(next) {


### PR DESCRIPTION
If create is set to false, it will not try to describe the table. Previously, if create was set to false and the table did not exist, the error from the describe table call would propagate and the model function would end up throwing it.
