### PR TITLE
Fixed table creation when global indexes contain non-indexed range keys.

### DIFF
--- a/lib/Table.js
+++ b/lib/Table.js
@@ -143,6 +143,10 @@ Table.prototype.create = function(next) {
   addKeyAttr(schema.rangeKey);
   for(var globalIndexName in schema.indexes.global) {
     addKeyAttr(schema.indexes.global[globalIndexName]);
+
+    // add the range key to the attribute definitions if specified
+    var rangeKeyName = schema.indexes.global[globalIndexName].indexes[globalIndexName].rangeKey;
+    addKeyAttr(schema.attributes[rangeKeyName]);
   }
   for(var indexName in schema.indexes.local) {
     addKeyAttr(schema.indexes.local[indexName]);

--- a/test/Table.js
+++ b/test/Table.js
@@ -19,8 +19,41 @@ describe('Table tests', function (){
   this.timeout(5000);
 
   var schema = new Schema({ id: Number, name: String, childern: [Number] });
+  var globalIndexSchema = new Schema({
+    ownerId: {
+      type: Number,
+      validate: function(v) { return v > 0; },
+      hashKey: true
+    },
+    breed: {
+      type: String,
+      rangeKey: true,
+      index: {
+        global: true,
+        rangeKey: 'color',
+        name: 'BreedGlobalIndex',
+        project: true, // ProjectionType: ALL
+        throughput: 5 // read and write are both 5
+      }
+    },
+    name: {
+      type: String,
+      required: true,
+      index: {
+        global: true,
+        name: 'NameGlobalIndex',
+        project: true, // ProjectionType: ALL
+        throughput: 5 // read and write are both 5
+      }
+    },
+    color: {
+      type: String,
+      default: 'Brown'
+    }
+  });
 
   var table = new Table('person', schema, null, dynamoose);
+  var globalIndexTable = new Table('dog', globalIndexSchema, null, dynamoose);
 
   it('Create simple table', function (done) {
 
@@ -60,4 +93,20 @@ describe('Table tests', function (){
     });
   });
 
+  it('Create table with global index with non indexed range key', function (done) {
+
+    globalIndexTable.create(function(err) {
+      should.not.exist(err);
+      done();
+    });
+  });
+
+  it('Delete table with global index', function (done) {
+
+    globalIndexTable.delete(function(err, data) {
+      should.not.exist(err);
+      should.exist(data);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
When creating a table, dynamoose was only passing in key and
indexed attributes in the AttributeDefinitions parameter.
If a range key on a global index was not one of those attributes,
the table creation would fail because the range key was not
specified in the AttributeDefinitions list.

This fix looks for range keys on global secondary indexes
and appends them to the AttributeDefinitions list.
