### PR TITLE
Version 2.0.0 Beta 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.12",
   "description": "Dynamoose is a modeling tool for Amazon's DynamoDB (inspired by Mongoose)",
   "main": "lib/index.js",
   "homepage": "https://github.com/dynamoose/dynamoose#readme",


### PR DESCRIPTION
## Version 2.0.0 Beta 12

- **BREAKING CHANGE FROM BETA 11** - DynamoDB set types are now defined as `{"type": Set, "schema": [String]}` as opposed to the former `[String]` or `{"type": [String]}`. This is more explict and makes it more clear that the type is a set.
- **BREAKING CHANGE FROM BETA 11** - `dynamoose.undefined` is now `dynamoose.UNDEFINED`
- Changing behavior of Model.transaction.condition to accept conditional instance.
- Fixing issue with and/or within Query/Scan conditional groups
- Improving table update support