### PR TITLE
Docs: Updates ES Modules instructions

### DIFF
--- a/docs/docs/getting_started/Import.mdx
+++ b/docs/docs/getting_started/Import.mdx
@@ -20,7 +20,7 @@ const dynamoose = require("dynamoose");
 <TabItem value="esmodules">
 
 ```js
-import { dynamoose } from "dynamoose";
+import dynamoose from "dynamoose";
 ```
 
 </TabItem>

--- a/docs/docs/getting_started/Import.mdx
+++ b/docs/docs/getting_started/Import.mdx
@@ -20,7 +20,7 @@ const dynamoose = require("dynamoose");
 <TabItem value="esmodules">
 
 ```js
-import dynamoose from "dynamoose";
+import * as dynamoose from "dynamoose";
 ```
 
 </TabItem>


### PR DESCRIPTION
### Summary:
It appears that dynamoose is a default export rather than a named import
Updating the documentation to help with getting started.

Using:
```ts
import { dynamoose } from 'dynamoose'
// Module '"project/node_modules/dynamoose/dist"' has no exported member 'dynamoose'.
```

Whereas
```ts
import dynamoose from 'dynamoose'
// Happy days
```

### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [x] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
