### PR TITLE
bug(model): allow "ON_DEMAND" in model options

### DIFF
--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -31,7 +31,7 @@ enum ModelUpdateOptions {
 }
 export interface ModelOptions {
 	create: boolean;
-	throughput: number | {read: number; write: number};
+	throughput: number | {read: number; write: number} | "ON_DEMAND";
 	prefix: string;
 	suffix: string;
 	waitForActive: ModelWaitForActiveSettings;


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:

Allow throughput to be "ON_DEMAND" in model options



<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
const model = dynamoose.model('Catalog', schema, {
	"create": true,
	throughput: "ON_DEMAND",
});
```

### Type (select 1):
- [X] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [X] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [X] Yes
- [ ] No


### Other:
- [X] I have read through and followed the Contributing Guidelines
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [ ] I have ensured the following commands are successful from the root of the project directory
  - [ ] `npm test`
  - [ ] `npm run lint`
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have filled out all fields above
