### PR TITLE
dynamoose.model(name)

### DIFF
--- a/docs/docs/guide/Model.md
+++ b/docs/docs/guide/Model.md
@@ -1,6 +1,6 @@
 The Model object represents a table in DynamoDB. It takes in both a name and a schema and has methods to retrieve, and save documents in the database.
 
-## dynamoose.model(name, schema[, config])
+## dynamoose.model(name, [schema][, config])
 
 This method is the basic entry point for creating a model in Dynamoose. When you call this method a new model is created, and it returns a Document initializer that you can use to create instances of the given model.
 
@@ -14,6 +14,12 @@ const Cat = dynamoose.model("Cat", {"name": String}, {"create": false});
 
 const Cat = dynamoose.model("Cat", new dynamoose.Schema({"name": String}));
 const Cat = dynamoose.model("Cat", new dynamoose.Schema({"name": String}), {"create": false});
+```
+
+If you don't pass the `schema` parameter it is required that you have an existing model already registed with that name. This will use the existing model already registered.
+
+```js
+const Cat = dynamoose.model("Cat"); // Will reference existing model, or if no model exists already with name `Cat` it will throw an error.
 ```
 
 The `config` parameter is an object used to customize settings for the model.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,12 +9,27 @@ import Internal = require("./Internal");
 import utils = require("./utils");
 import logger = require("./logger");
 import {Document} from "./Document";
+import ModelStore = require("./ModelStore");
 
 interface ModelDocumentConstructor<T extends Document> {
 	new (object: {[key: string]: any}): T;
 }
-const model = <T extends Document>(name: string, schema: Schema | SchemaDefinition, options: ModelOptionsOptional = {}): T & Model<T> & ModelDocumentConstructor<T> => {
-	const model: Model<T> = new Model(name, schema, options);
+
+const model = <T extends Document>(name: string, schema?: Schema | SchemaDefinition, options: ModelOptionsOptional = {}): T & Model<T> & ModelDocumentConstructor<T> => {
+	let model: Model<T>;
+	let storedSchema: Model<T>;
+	if (name) {
+		storedSchema = ModelStore(name);
+	}
+	// TODO: this is something I'd like to do. But is a breaking change. Need to enable this and uncomment it in a breaking release. Also will need to fix the tests as well.
+	/* if (schema && storedSchema) {
+		throw new CustomError.InvalidParameter(`Model with name ${name} has already been registered.`);
+	} else */
+	if (!schema && storedSchema) {
+		model = storedSchema;
+	} else {
+		model = new Model(name, schema, options);
+	}
 	const returnObject: any = model.Document;
 	const keys = utils.array_flatten([
 		Object.keys(model),

--- a/test/Model.js
+++ b/test/Model.js
@@ -7,6 +7,7 @@ const Error = require("../dist/Error");
 const Internal = require("../dist/Internal");
 const utils = require("../dist/utils");
 const util = require("util");
+const ModelStore = require("../dist/ModelStore");
 
 describe("Model", () => {
 	beforeEach(() => {
@@ -25,12 +26,28 @@ describe("Model", () => {
 	});
 
 	describe("Initialization", () => {
-		it("Should throw an error if no schema is passed in", () => {
+		it("Should throw an error if no schema is passed in and no existing model in store", () => {
 			expect(() => dynamoose.model("Cat")).to.throw(Error.MissingSchemaError);
+			expect(() => dynamoose.model("Cat")).to.throw("Schema hasn't been registered for model \"Cat\".\nUse \"dynamoose.model(name, schema)\"");
 		});
 
 		it("Should throw same error as no schema if nothing passed in", () => {
 			expect(() => dynamoose.model()).to.throw(Error.MissingSchemaError);
+			expect(() => dynamoose.model()).to.throw("Schema hasn't been registered for model \"undefined\".\nUse \"dynamoose.model(name, schema)\"");
+		});
+
+		it("Should return existing model if already exists and not passing in schema", () => {
+			const User = dynamoose.model("User", {"id": String});
+			const UserB = dynamoose.model("User");
+
+			expect(UserB).to.eql(User);
+		});
+
+		it("Should throw error if passing in model with same name as existing model", () => {
+			dynamoose.model("User", {"id": String});
+			dynamoose.model("User", {"id": String, "name": String});
+
+			expect(ModelStore("User").schema.schemaObject).to.eql({"id": String, "name": String});
 		});
 
 		it("Should create a schema if not passing in schema instance", () => {


### PR DESCRIPTION
This PR adds support for not passing a Schema into `dynamoose.model` and referencing an existing model by name. In the event you don't have an existing model registered, it will throw an error.

Close #856