### PR TITLE
Model.waitForActive.check should have been optional

### DIFF
--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -15,7 +15,7 @@ import {DynamoDB, AWSError} from "aws-sdk";
 // Defaults
 interface ModelWaitForActiveSettings {
 	enabled: boolean;
-	check: {timeout: number; frequency: number};
+	check?: {timeout: number; frequency: number};
 }
 export interface ModelExpiresSettings {
 	ttl: number;


### PR DESCRIPTION
@fishcharlie After throughput this is the second attribute that should have been optional but was not. If you have time could you please check all interfaces if there are more things that should be optional but are not?

Btw. I dont know if this `Partial` interface is a good idea. Why use `Partial<ModelOptions>` if already `ModelOptions` can set what attributes are optional and which are required?