### PR TITLE
Version 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ---
 
+## Version 2.1.2
+
+This release fixes a few minor bugs with `Model.update`.
+
+Please comment or [contact me](https://charlie.fish/contact) if you have any questions about this release.
+
+### Bug Fixes
+
+- Fixed an issue where `Model.update` using `$REMOVE` wouldn't work on non defined attributes using `saveUnknown`
+- Fixed an issue where `Model.update` would throw an AWS error `ExpressionAttributeValues must not be empty` when using `$REMOVE`
+
+---
+
 ## Version 2.1.1
 
 This release fixes some bugs related to TypeScript and improves the website with more accurate information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Dynamoose is a modeling tool for Amazon's DynamoDB (inspired by Mongoose)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Version 2.1.2

This release fixes a few minor bugs with `Model.update`.

Please comment or [contact me](https://charlie.fish/contact) if you have any questions about this release.

### Bug Fixes

- Fixed an issue where `Model.update` using `$REMOVE` wouldn't work on non defined attributes using `saveUnknown`
- Fixed an issue where `Model.update` would throw an AWS error `ExpressionAttributeValues must not be empty` when using `$REMOVE`