### PR TITLE
Add breaking change note - string attributes no longer implicitly converted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Please comment or [contact me](https://charlie.fish/contact) if you have any que
 - `Model.transaction.conditionCheck` has been renamed to `Model.transaction.condition`
 - `Model.transaction.condition` now accepts a conditional instance instead of an object to specify the conditional you wish to run
 - In the past the `saveUnknown` option for attribute names would handle all nested properties. Now you must use `*` to indicate one level of wildcard or `**` to indicate infinate levels of wildcard. So if you have an object property (`address`) and want to parse one level of values (no sub objects) you can use `address.*`, or `address.**` to all for infinate levels of values (including sub objects)
+- In the past non-string type properties would be implicitly coerced into strings with a call to their `toString()` methods when saved as `String` type attributes. This will now throw a `TypeMismatch` error. Strings should be converted before saving.
 - `useNativeBooleans` & `useDocumentTypes` have been removed from the Model settings
 - `scan.count()` has been removed, and `scan.counts()` has been renamed to `scan.count()`.
 - The attribute types `Array` & `Object` in Dynamoose v1 don't work without a `schema` option in v2


### PR DESCRIPTION
Add breaking change note to v2.0.0 - string attributes no longer implicitly converted.

<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:

Add breaking change note that non-string properties will no longer be converted when saved to a string attribute. 

For example, a mongoose ID object will no longer be automatically converted and saved as a string.

<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->  Closes #870 
#---

### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [x] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
