### PR TITLE
Converting AttributesToGet to ProjectionExpression

### DIFF
--- a/docs/docs/guide/Query.md
+++ b/docs/docs/guide/Query.md
@@ -85,6 +85,8 @@ This function will limit which attributes DynamoDB returns for each item in the 
 Cat.query("name").eq("Will").attributes(["id", "name"]); // Return all documents but only return the `id` & `name` properties for each item
 ```
 
+This function uses the `ProjectionExpression` DynamoDB property to save bandwidth and not send the entire item over the wire.
+
 ## query.count()
 
 Instead of returning an array of documents this function will cause the query operation to return a special object with the count information for the query. The response you will receive from the query operation with this setting will be an object with the properties `count` & `queriedCount`, which have the same values as described in [`query.exec([callback])`](#queryexeccallback).

--- a/docs/docs/guide/Scan.md
+++ b/docs/docs/guide/Scan.md
@@ -86,6 +86,8 @@ This function will limit which attributes DynamoDB returns for each item in the 
 Cat.scan().attributes(["id", "name"]); // Return all documents but only return the `id` & `name` properties for each item
 ```
 
+This function uses the `ProjectionExpression` DynamoDB property to save bandwidth and not send the entire item over the wire.
+
 ## scan.parallel(parallelScans)
 
 This function will run parallel scans on your table. The `parallelScans` parameter should be a number representing how many concurrent scans you wish to preform on the table. The results will be merged into a single array, with the `count`, `scannedCount`, & `timesScanned` properties being summed in the response. In the event there are multiple `lastKey` properties these will be merged into an array of objects.

--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -178,7 +178,7 @@ DocumentRetriever.prototype.getRequest = async function(this: DocumentRetriever)
 		object.ExclusiveStartKey = Document.isDynamoObject(this.settings.startAt) ? this.settings.startAt : this.internalSettings.model.Document.objectToDynamo(this.settings.startAt);
 	}
 	if (this.settings.attributes) {
-		object.AttributesToGet = this.settings.attributes;
+		object.ProjectionExpression = this.settings.attributes.join(", ");
 	}
 	const indexes = await this.internalSettings.model.schema.getIndexes(this.internalSettings.model);
 	if (this.settings.index) {

--- a/test/Query.js
+++ b/test/Query.js
@@ -1166,7 +1166,13 @@ describe("Query", () => {
 		it("Should send correct request on query.exec", async () => {
 			queryPromiseResolver = () => ({"Items": []});
 			await Model.query("name").eq("Charlie").attributes(["id"]).exec();
-			expect(queryParams.AttributesToGet).to.eql(["id"]);
+			expect(queryParams.ProjectionExpression).to.eql("id");
+		});
+
+		it("Should send correct request on query.exec with multiple attributes", async () => {
+			queryPromiseResolver = () => ({"Items": []});
+			await Model.query("name").eq("Charlie").attributes(["id", "name"]).exec();
+			expect(queryParams.ProjectionExpression).to.eql("id, name");
 		});
 	});
 

--- a/test/Scan.js
+++ b/test/Scan.js
@@ -608,9 +608,16 @@ describe("Scan", () => {
 
 		it("Should send correct request on scan.exec", async () => {
 			scanPromiseResolver = () => ({"Items": []});
-			await Model.scan().attributes(["id"]).exec();
-			expect(scanParams.AttributesToGet).to.eql(["id"]);
+			await Model.scan("name").eq("Charlie").attributes(["id"]).exec();
+			expect(scanParams.ProjectionExpression).to.eql("id");
 		});
+
+		it("Should send correct request on scan.exec with multiple attributes", async () => {
+			scanPromiseResolver = () => ({"Items": []});
+			await Model.scan("name").eq("Charlie").attributes(["id", "name"]).exec();
+			expect(scanParams.ProjectionExpression).to.eql("id, name");
+		});
+
 	});
 
 	describe("scan.parallel", () => {


### PR DESCRIPTION
This pull request removes the legacy `AttributesToGet` property and migrates to `ProjectionExpression`. Related: #881