### PR TITLE
Strongly typed models

### DIFF
--- a/lib/Condition.ts
+++ b/lib/Condition.ts
@@ -1,19 +1,19 @@
-import {Document} from "./Document";
+import { Document } from "./Document";
 import CustomError = require("./Error");
 import utils = require("./utils");
 const OR = Symbol("OR");
-import {DynamoDB} from "aws-sdk";
+import { DynamoDB } from "aws-sdk";
 import { ObjectType } from "./General";
 
 const isRawConditionObject = (object): boolean => Object.keys(object).length === 3 && ["ExpressionAttributeValues", "ExpressionAttributeNames"].every((item) => Boolean(object[item]) && typeof object[item] === "object");
 
 export type ConditionFunction = (condition: Condition) => Condition;
 // TODO: There is a problem where you can have multiple keys in one `ConditionStorageType`, which will cause problems. We need to fix that. Likely be refactoring it so that the key is part of `ConditionsConditionStorageObject`.
-type ConditionStorageType = {[key: string]: ConditionsConditionStorageObject} | typeof OR;
+type ConditionStorageType = { [key: string]: ConditionsConditionStorageObject } | typeof OR;
 type ConditionStorageTypeNested = ConditionStorageType | Array<ConditionStorageTypeNested>;
 type ConditionStorageSettingsConditions = ConditionStorageTypeNested[];
 // TODO: the return value of the function below is incorrect. We need to add a property to the object that is a required string, where the property/key name is always equal to `settings.conditionString`
-type ConditionRequestObjectResult = {ExpressionAttributeNames?: DynamoDB.Types.ExpressionAttributeNameMap; ExpressionAttributeValues?: DynamoDB.Types.ExpressionAttributeValueMap};
+type ConditionRequestObjectResult = { ExpressionAttributeNames?: DynamoDB.Types.ExpressionAttributeNameMap; ExpressionAttributeValues?: DynamoDB.Types.ExpressionAttributeValueMap };
 
 interface ConditionComparisonType {
 	name: ConditionComparisonComparatorName;
@@ -49,20 +49,41 @@ enum ConditionComparisonComparatorDynamoName {
 	between = "BETWEEN"
 }
 const types: ConditionComparisonType[] = [
-	{"name": ConditionComparisonComparatorName.equals, "typeName": ConditionComparisonComparatorDynamoName.equals, "not": ConditionComparisonComparatorDynamoName.notEquals},
-	{"name": ConditionComparisonComparatorName.lessThan, "typeName": ConditionComparisonComparatorDynamoName.lessThan, "not": ConditionComparisonComparatorDynamoName.greaterThanEquals},
-	{"name": ConditionComparisonComparatorName.lessThanEquals, "typeName": ConditionComparisonComparatorDynamoName.lessThanEquals, "not": ConditionComparisonComparatorDynamoName.greaterThan},
-	{"name": ConditionComparisonComparatorName.greaterThan, "typeName": ConditionComparisonComparatorDynamoName.greaterThan, "not": ConditionComparisonComparatorDynamoName.lessThanEquals},
-	{"name": ConditionComparisonComparatorName.greaterThanEquals, "typeName": ConditionComparisonComparatorDynamoName.greaterThanEquals, "not": ConditionComparisonComparatorDynamoName.lessThan},
-	{"name": ConditionComparisonComparatorName.beginsWith, "typeName": ConditionComparisonComparatorDynamoName.beginsWith},
-	{"name": ConditionComparisonComparatorName.contains, "typeName": ConditionComparisonComparatorDynamoName.contains, "not": ConditionComparisonComparatorDynamoName.notContains},
-	{"name": ConditionComparisonComparatorName.exists, "typeName": ConditionComparisonComparatorDynamoName.exists, "not": ConditionComparisonComparatorDynamoName.notExists},
-	{"name": ConditionComparisonComparatorName.in, "typeName": ConditionComparisonComparatorDynamoName.in},
-	{"name": ConditionComparisonComparatorName.between, "typeName": ConditionComparisonComparatorDynamoName.between, "multipleArguments": true}
+	{ "name": ConditionComparisonComparatorName.equals, "typeName": ConditionComparisonComparatorDynamoName.equals, "not": ConditionComparisonComparatorDynamoName.notEquals },
+	{ "name": ConditionComparisonComparatorName.lessThan, "typeName": ConditionComparisonComparatorDynamoName.lessThan, "not": ConditionComparisonComparatorDynamoName.greaterThanEquals },
+	{ "name": ConditionComparisonComparatorName.lessThanEquals, "typeName": ConditionComparisonComparatorDynamoName.lessThanEquals, "not": ConditionComparisonComparatorDynamoName.greaterThan },
+	{ "name": ConditionComparisonComparatorName.greaterThan, "typeName": ConditionComparisonComparatorDynamoName.greaterThan, "not": ConditionComparisonComparatorDynamoName.lessThanEquals },
+	{ "name": ConditionComparisonComparatorName.greaterThanEquals, "typeName": ConditionComparisonComparatorDynamoName.greaterThanEquals, "not": ConditionComparisonComparatorDynamoName.lessThan },
+	{ "name": ConditionComparisonComparatorName.beginsWith, "typeName": ConditionComparisonComparatorDynamoName.beginsWith },
+	{ "name": ConditionComparisonComparatorName.contains, "typeName": ConditionComparisonComparatorDynamoName.contains, "not": ConditionComparisonComparatorDynamoName.notContains },
+	{ "name": ConditionComparisonComparatorName.exists, "typeName": ConditionComparisonComparatorDynamoName.exists, "not": ConditionComparisonComparatorDynamoName.notExists },
+	{ "name": ConditionComparisonComparatorName.in, "typeName": ConditionComparisonComparatorDynamoName.in },
+	{ "name": ConditionComparisonComparatorName.between, "typeName": ConditionComparisonComparatorDynamoName.between, "multipleArguments": true }
 ];
 export type ConditionInitalizer = Condition | ObjectType | string;
 
-export class Condition {
+export interface BasicOperators<T = Condition> {
+	and: () => T;
+	or: () => T;
+	not: () => T;
+	parenthesis: (value: T | ConditionFunction) => T;
+	group: (value: T | ConditionFunction) => T;
+	where: (key: string) => T;
+	filter: (key: string) => T;
+	attribute: (key: string) => T;
+	eq: (value: any) => T;
+	lt: (value: number) => T;
+	le: (value: number) => T;
+	gt: (value: number) => T;
+	ge: (value: number) => T;
+	beginsWith: (value: any) => T;
+	contains: (value: any) => T;
+	exists: (value: any) => T;
+	in: (value: any) => T;
+	between: (...values: any[]) => T;
+}
+
+export interface Condition extends BasicOperators {
 	settings: {
 		// TODO: fix this below, it should be a reference to `OR` not Symbol, you are only allowed to pass in OR here, not any other Symbol.
 		conditions: ConditionStorageSettingsConditions;
@@ -74,27 +95,11 @@ export class Condition {
 		};
 		raw?: ConditionInitalizer;
 	};
-	and: () => Condition;
-	or: () => Condition;
-	not: () => Condition;
-	parenthesis: (value: Condition | ConditionFunction) => Condition;
-	group: (value: Condition | ConditionFunction) => Condition;
-	where: (key: string) => Condition;
-	filter: (key: string) => Condition;
-	attribute: (key: string) => Condition;
-	eq: (value: any) => Condition;
-	lt: (value: number) => Condition;
-	le: (value: number) => Condition;
-	gt: (value: number) => Condition;
-	ge: (value: number) => Condition;
-	beginsWith: (value: any) => Condition;
-	contains: (value: any) => Condition;
-	exists: (value: any) => Condition;
-	in: (value: any) => Condition;
-	between: (...values: any[]) => Condition;
-
 	requestObject: (settings?: ConditionRequestObjectSettings) => ConditionRequestObjectResult;
 
+}
+
+export class Condition {
 	constructor(object?: ConditionInitalizer) {
 		if (object instanceof Condition) {
 			Object.entries(object).forEach((entry) => {
@@ -169,22 +174,22 @@ Condition.prototype.parenthesis = Condition.prototype.group = function (this: Co
 	this.settings.conditions.push(value.settings.conditions);
 	return this;
 };
-Condition.prototype.or = function(this: Condition): Condition {
+Condition.prototype.or = function (this: Condition): Condition {
 	this.settings.conditions.push(OR);
 	return this;
 };
-Condition.prototype.and = function(this: Condition): Condition { return this; };
-Condition.prototype.not = function(this: Condition): Condition {
+Condition.prototype.and = function (this: Condition): Condition { return this; };
+Condition.prototype.not = function (this: Condition): Condition {
 	this.settings.pending.not = !this.settings.pending.not;
 	return this;
 };
-Condition.prototype.where = Condition.prototype.filter = Condition.prototype.attribute = function(this: Condition, key: string): Condition {
-	this.settings.pending = {key};
+Condition.prototype.where = Condition.prototype.filter = Condition.prototype.attribute = function (this: Condition, key: string): Condition {
+	this.settings.pending = { key };
 	return this;
 };
 // TODO: I don't think this prototypes are being exposed which is gonna cause a lot of problems with our type definition file. Need to figure out a better way to do this since they aren't defined and are dynamic.
 types.forEach((type) => {
-	Condition.prototype[type.name] = function(this: Condition, ...args: any[]): Condition {
+	Condition.prototype[type.name] = function (this: Condition, ...args: any[]): Condition {
 		this.settings.pending.value = type.multipleArguments ? args : args[0];
 		this.settings.pending.type = type;
 		finalizePending(this);
@@ -200,13 +205,13 @@ interface ConditionRequestObjectSettings {
 	};
 	conditionStringType: "array" | "string";
 }
-Condition.prototype.requestObject = function(this: Condition, settings: ConditionRequestObjectSettings = {"conditionString": "ConditionExpression", "conditionStringType": "string"}): ConditionRequestObjectResult {
+Condition.prototype.requestObject = function (this: Condition, settings: ConditionRequestObjectSettings = { "conditionString": "ConditionExpression", "conditionStringType": "string" }): ConditionRequestObjectResult {
 	if (this.settings.raw && utils.object.equals(Object.keys(this.settings.raw).sort(), [settings.conditionString, "ExpressionAttributeValues", "ExpressionAttributeNames"].sort())) {
 		return Object.entries((this.settings.raw as ObjectType).ExpressionAttributeValues).reduce((obj, entry) => {
 			const [key, value] = entry;
 			// TODO: we should fix this so that we can do `isDynamoItem(value)`
-			if (!Document.isDynamoObject({"key": value})) {
-				obj.ExpressionAttributeValues[key] = Document.objectToDynamo(value, {"type": "value"});
+			if (!Document.isDynamoObject({ "key": value })) {
+				obj.ExpressionAttributeValues[key] = Document.objectToDynamo(value, { "type": "value" });
 			}
 			return obj;
 		}, this.settings.raw as ObjectType);
@@ -215,21 +220,21 @@ Condition.prototype.requestObject = function(this: Condition, settings: Conditio
 	}
 
 	let index = (settings.index || {}).start || 0;
-	const setIndex = (i: number): void => {index = i; (settings.index || {"set": utils.empty_function}).set(i);};
+	const setIndex = (i: number): void => { index = i; (settings.index || { "set": utils.empty_function }).set(i); };
 	function main(input: ConditionStorageSettingsConditions): ConditionRequestObjectResult {
 		return input.reduce((object: ConditionRequestObjectResult, entry: ConditionStorageTypeNested, i: number, arr: any[]) => {
 			let expression = "";
 			if (Array.isArray(entry)) {
 				const result = main(entry);
-				const newData = utils.merge_objects.main({"combineMethod": "object_combine"})({...result}, {...object});
+				const newData = utils.merge_objects.main({ "combineMethod": "object_combine" })({ ...result }, { ...object });
 				const returnObject = utils.object.pick(newData, ["ExpressionAttributeNames", "ExpressionAttributeValues"]);
 
 				expression = settings.conditionStringType === "array" ? result[settings.conditionString] : `(${result[settings.conditionString]})`;
-				object = {...object, ...returnObject};
+				object = { ...object, ...returnObject };
 			} else if (entry !== OR) {
 				const [key, condition] = Object.entries(entry)[0];
-				const {value} = condition;
-				const keys = {"name": `#a${index}`, "value": `:v${index}`};
+				const { value } = condition;
+				const keys = { "name": `#a${index}`, "value": `:v${index}` };
 				setIndex(++index);
 
 				const keyParts = key.split(".");
@@ -244,7 +249,7 @@ Condition.prototype.requestObject = function(this: Condition, settings: Conditio
 					}, []).join(".");
 				}
 				const toDynamo = (value: ObjectType): DynamoDB.AttributeValue => {
-					return Document.objectToDynamo(value, {"type": "value"});
+					return Document.objectToDynamo(value, { "type": "value" });
 				};
 				object.ExpressionAttributeValues[keys.value] = toDynamo(value);
 
@@ -302,7 +307,7 @@ Condition.prototype.requestObject = function(this: Condition, settings: Conditio
 			});
 
 			return object;
-		}, {[settings.conditionString]: settings.conditionStringType === "array" ? [] : "", "ExpressionAttributeNames": {}, "ExpressionAttributeValues": {}});
+		}, { [settings.conditionString]: settings.conditionStringType === "array" ? [] : "", "ExpressionAttributeNames": {}, "ExpressionAttributeValues": {} });
 	}
 	return main(this.settings.conditions);
 };

--- a/lib/Document.ts
+++ b/lib/Document.ts
@@ -77,8 +77,8 @@ export class Document {
 	}
 
 	static attributesWithSchema: (document: Document, model: Model<Document>) => string[];
-	static objectFromSchema: (object: any, model: Model<Document>, settings?: DocumentObjectFromSchemaSettings) => Promise<any>;
-	static prepareForObjectFromSchema: (object: any, model: Model<Document>, settings: DocumentObjectFromSchemaSettings) => any;
+	static objectFromSchema: (object: any, model: Model<Document,any>, settings?: DocumentObjectFromSchemaSettings) => Promise<any>;
+	static prepareForObjectFromSchema: (object: any, model: Model<Document,any>, settings: DocumentObjectFromSchemaSettings) => any;
 	conformToSchema: (this: Document, settings?: DocumentObjectFromSchemaSettings) => Promise<Document>;
 	toDynamo: (this: Document, settings?: Partial<DocumentObjectFromSchemaSettings>) => Promise<any>;
 

--- a/lib/Document.ts
+++ b/lib/Document.ts
@@ -20,6 +20,8 @@ export interface DocumentSettings {
 	type?: "fromDynamo" | "toDynamo";
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Document {}
 // Document represents an item in a Model that is either pending (not saved) or saved
 export class Document {
 	constructor(model: Model<Document>, object?: DynamoDB.AttributeMap | ObjectType, settings?: DocumentSettings) {

--- a/lib/Document.ts
+++ b/lib/Document.ts
@@ -20,8 +20,6 @@ export interface DocumentSettings {
 	type?: "fromDynamo" | "toDynamo";
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Document {}
 // Document represents an item in a Model that is either pending (not saved) or saved
 export class Document {
 	constructor(model: Model<Document>, object?: DynamoDB.AttributeMap | ObjectType, settings?: DocumentSettings) {

--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -286,18 +286,18 @@ DocumentRetriever.prototype.all = function(this: DocumentRetriever, delay = 0, m
 	return this;
 };
 
-export interface Scan extends DocumentRetriever,  BasicOperators<Scan>{
-	exec(): Promise<ScanResponse<Document[]>>;
+export interface Scan<T extends Document> extends DocumentRetriever,  BasicOperators<Scan<T>>{
+	exec(): Promise<ScanResponse<T[]>>;
 	exec(callback: CallbackType<ScanResponse<Document[]>, AWSError>): void;
 }
 
-export class Scan extends DocumentRetriever {
+export class Scan<T> extends DocumentRetriever {
 
 	exec(callback?: CallbackType<ScanResponse<Document[]>, AWSError>): Promise<ScanResponse<Document[]>> | void {
 		return super.exec(callback);
 	}
 
-	parallel(value: number): Scan {
+	parallel(value: number): Scan<T> {
 		this.settings.parallel = value;
 		return this;
 	}
@@ -307,12 +307,12 @@ export class Scan extends DocumentRetriever {
 	}
 }
 
-export interface Query extends DocumentRetriever,  BasicOperators<Query>{
-	exec(): Promise<QueryResponse<Document[]>>;
+export interface Query<T extends Document> extends DocumentRetriever,  BasicOperators<Query<T>>{
+	exec(): Promise<QueryResponse<T[]>>;
 	exec(callback: CallbackType<QueryResponse<Document[]>, AWSError>): void;
 }
 
-export class Query extends DocumentRetriever {
+export class Query<T extends Document> extends DocumentRetriever {
 	exec(callback?: CallbackType<QueryResponse<Document[]>, AWSError>): Promise<QueryResponse<Document[]>> | void {
 		return super.exec(callback);
 	}

--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -1,7 +1,7 @@
 import ddb = require("./aws/ddb/internal");
 import CustomError = require("./Error");
 import utils = require("./utils");
-import {Condition, ConditionInitalizer, ConditionFunction} from "./Condition";
+import {Condition, ConditionInitalizer,  BasicOperators} from "./Condition";
 import {Model} from "./Model";
 import {Document} from "./Document";
 import { CallbackType, ObjectType } from "./General";
@@ -15,8 +15,9 @@ interface DocumentRetrieverTypeInformation {
 	type: DocumentRetrieverTypes;
 	pastTense: string;
 }
+
 // DocumentRetriever is used for both Scan and Query since a lot of the code is shared between the two
-abstract class DocumentRetriever {
+abstract class DocumentRetriever{
 	internalSettings?: {
 		model: Model<Document>;
 		typeInformation: DocumentRetrieverTypeInformation;
@@ -111,31 +112,6 @@ abstract class DocumentRetriever {
 			})();
 		}
 	}
-
-
-
-	// TODO: this was all copied from Condition.ts, we need to figure out a better way to handle this --------------------------------------------------
-	and: () => Condition;
-	or: () => Condition;
-	not: () => Condition;
-	parenthesis: (value: Condition | ConditionFunction) => Condition;
-	group: (value: Condition | ConditionFunction) => Condition;
-	where: (key: string) => Condition;
-	filter: (key: string) => Condition;
-	attribute: (key: string) => Condition;
-	eq: (value: any) => Condition;
-	lt: (value: number) => Condition;
-	le: (value: number) => Condition;
-	gt: (value: number) => Condition;
-	ge: (value: number) => Condition;
-	beginsWith: (value: any) => Condition;
-	contains: (value: any) => Condition;
-	exists: (value: any) => Condition;
-	in: (value: any) => Condition;
-	between: (...values: any[]) => Condition;
-	// -------------------------------------------------------------------------------------------------------------------------------------------------
-
-
 
 
 
@@ -310,10 +286,13 @@ DocumentRetriever.prototype.all = function(this: DocumentRetriever, delay = 0, m
 	return this;
 };
 
-
-export class Scan extends DocumentRetriever {
+export interface Scan extends DocumentRetriever,  BasicOperators<Scan>{
 	exec(): Promise<ScanResponse<Document[]>>;
 	exec(callback: CallbackType<ScanResponse<Document[]>, AWSError>): void;
+}
+
+export class Scan extends DocumentRetriever {
+
 	exec(callback?: CallbackType<ScanResponse<Document[]>, AWSError>): Promise<ScanResponse<Document[]>> | void {
 		return super.exec(callback);
 	}
@@ -328,9 +307,12 @@ export class Scan extends DocumentRetriever {
 	}
 }
 
-export class Query extends DocumentRetriever {
+export interface Query extends DocumentRetriever,  BasicOperators<Query>{
 	exec(): Promise<QueryResponse<Document[]>>;
 	exec(callback: CallbackType<QueryResponse<Document[]>, AWSError>): void;
+}
+
+export class Query extends DocumentRetriever {
 	exec(callback?: CallbackType<QueryResponse<Document[]>, AWSError>): Promise<QueryResponse<Document[]>> | void {
 		return super.exec(callback);
 	}

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -822,13 +822,13 @@ export class Model<T extends DocumentCarrier> {
 	}
 
 	// Get
-	get(this: Model<DocumentCarrier>, key: InputKey): Promise<DocumentCarrier>;
+	get(this: Model<DocumentCarrier>, key: InputKey): Promise<T>;
 	get(this: Model<DocumentCarrier>, key: InputKey, callback: CallbackType<DocumentCarrier, AWSError>): void;
-	get(this: Model<DocumentCarrier>, key: InputKey, settings: ModelGetSettings & {return: "document"}): Promise<DocumentCarrier>;
-	get(this: Model<DocumentCarrier>, key: InputKey, settings: ModelGetSettings & {return: "document"}, callback: CallbackType<DocumentCarrier, AWSError>): void;
+	get(this: Model<DocumentCarrier>, key: InputKey, settings: ModelGetSettings & {return: "document"}): Promise<T>;
+	get(this: Model<DocumentCarrier>, key: InputKey, settings: ModelGetSettings & {return: "document"}, callback: CallbackType<T, AWSError>): void;
 	get(this: Model<DocumentCarrier>, key: InputKey, settings: ModelGetSettings & {return: "request"}): DynamoDB.GetItemInput;
 	get(this: Model<DocumentCarrier>, key: InputKey, settings: ModelGetSettings & {return: "request"}, callback: CallbackType<DynamoDB.GetItemInput, AWSError>): void;
-	get(this: Model<DocumentCarrier>, key: InputKey, settings?: ModelGetSettings | CallbackType<DocumentCarrier, AWSError> | CallbackType<DynamoDB.GetItemInput, AWSError>, callback?: CallbackType<DocumentCarrier, AWSError> | CallbackType<DynamoDB.GetItemInput, AWSError>): void | DynamoDB.GetItemInput | Promise<DocumentCarrier> {
+	get(this: Model<DocumentCarrier>, key: InputKey, settings?: ModelGetSettings | CallbackType<T, AWSError> | CallbackType<DynamoDB.GetItemInput, AWSError>, callback?: CallbackType<T, AWSError> | CallbackType<DynamoDB.GetItemInput, AWSError>): void | DynamoDB.GetItemInput | Promise<T> {
 		if (typeof settings === "function") {
 			callback = settings;
 			settings = {"return": "document"};
@@ -864,6 +864,10 @@ export class Model<T extends DocumentCarrier> {
 			})();
 		}
 	}
+}
+
+export interface Model<T> {
+	new(doc?: Partial<T>): T;
 }
 
 Model.defaults = originalDefaults;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -54,9 +54,10 @@ export = {
 	model,
 	Schema,
 	Condition,
-	Document,
 	transaction,
 	aws,
 	logger,
 	"UNDEFINED": Internal.Public.undefined
 };
+
+exports.Document = Document;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,7 +10,7 @@ import utils = require("./utils");
 import logger = require("./logger");
 import {Document} from "./Document";
 
-const model = <T extends Document>(name: string, schema: Schema | SchemaDefinition, options: ModelOptionsOptional = {}): T => {
+const model = <T extends Document>(name: string, schema: Schema | SchemaDefinition, options: ModelOptionsOptional = {}): Model<T> => {
 	const model: Model<T> = new Model(name, schema, options);
 	const returnObject: any = model.Document;
 	const keys = utils.array_flatten([
@@ -50,14 +50,14 @@ model.defaults = {
 	...require("./Model/defaults").custom
 };
 
-export = {
+export  {
 	model,
 	Schema,
 	Condition,
+	Document,
 	transaction,
 	aws,
 	logger,
-	"UNDEFINED": Internal.Public.undefined
 };
 
-exports.Document = Document;
+export const UNDEFINED= Internal.Public.undefined;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -57,6 +57,7 @@ export = {
 	model,
 	Schema,
 	Condition,
+	Document,
 	transaction,
 	aws,
 	logger,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -60,4 +60,4 @@ export  {
 	logger,
 };
 
-export const UNDEFINED= Internal.Public.undefined;
+export const UNDEFINED = Internal.Public.undefined;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,10 +10,7 @@ import utils = require("./utils");
 import logger = require("./logger");
 import {Document} from "./Document";
 
-interface ModelDocumentConstructor<T extends Document> {
-	new (object: {[key: string]: any}): T;
-}
-const model = <T extends Document>(name: string, schema: Schema | SchemaDefinition, options: ModelOptionsOptional = {}): T & Model<T> & ModelDocumentConstructor<T> => {
+const model = <T extends Document>(name: string, schema: Schema | SchemaDefinition, options: ModelOptionsOptional = {}): T => {
 	const model: Model<T> = new Model(name, schema, options);
 	const returnObject: any = model.Document;
 	const keys = utils.array_flatten([
@@ -24,7 +21,7 @@ const model = <T extends Document>(name: string, schema: Schema | SchemaDefiniti
 	keys.forEach((key) => {
 		if (typeof model[key] === "object") {
 			const main = (key: string): void => {
-				utils.object.set(returnObject, key, {});
+				utils.object.set<T>(returnObject, key, {});
 				const value = utils.object.get(model as any, key);
 				if (value === null) {
 					utils.object.set(returnObject, key, value);
@@ -47,7 +44,7 @@ const model = <T extends Document>(name: string, schema: Schema | SchemaDefiniti
 			returnObject[key] = model[key];
 		}
 	});
-	return returnObject as any;
+	return returnObject;
 };
 model.defaults = {
 	...require("./Model/defaults").custom


### PR DESCRIPTION
### Summary:
This PR is a result of #889 question. After looking around and trying to find a solution for creating a dynamic interface based on the Schema, and have documents conform to it, I must sadly say that typescript is not there yet to achieve this.

But the basic functionality of strongly typed models is still achievable and this Library was almost there when it comes to type definitions.

So for starters:

_What I want to achieve is:_  
https://medium.com/@tomanagle/strongly-typed-models-with-mongoose-and-typescript-7bc2f7197722

_How I want to achieve it:_
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a2bc1d868d81733a8969236655fa600bd3651a7b/types/mongoose/index.d.ts#L213

~~**Why is this PART 1?**~~
~~I could go all over the project and start correcting (mostly) return types to have correctly typed models and documents, but instead, I've chosen a strategy for solving my problems. This way I can see the library behaving correctly based on real usage. More I will use it, more types I can add.~~


### Code sample:
#### Model
```typescript
interface Stat extends Document {
  id: string;
  tasks: number;
  resolvedTasks: number;
  revenue: number;
  payedOut: number;
  users: number;
}

const Stat = dynamoose.model<Stat>(
  'Stat',
  new dynamoose.Schema({
    id: String,
    tasks: Number,
    resolvedTasks: Number,
    revenue: Number,
    payedOut: Number,
    users: Number,
  }),
  { create: false },
);
```

#### General
```typescript
const stat = new Stat({ id: '1', tasks: 0, resolvedTasks: 0, revenue: 0, payedOut: 0, users: 0 });
const stat = await Stat.get('1');
```


### GitHub linked issue:
Closes #889 
#---


### Other information:
Currently constructing and retrieving documents trough get will infer the correct type.

You may also see that mongoose is using any in their `new` signature but I instead chose to use `Partial<T>`  instead so there can be type checks to some extent when creating new Doc.

**IMPORTANT Export**
I had to change export from the index of the library. I am not sure why `export =` was used (feel free to fill me in on this). I needed to export _Document_ since custom interfaces HAVE TO extend _Document_ (and that was also a big issue I had when creating custom interfaces). If it was exported trough `export = { Document }`, typescript wouldn't allow an interface to extend _Document_ since it would treat it as a value and not as a type.

### Type (select 1):
- [ ] Bug fix
- [X] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [X] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [X] Yes
- [ ] No


### Other:
- [X] I have read through and followed the Contributing Guidelines
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [X] I have ensured the following commands are successful from the root of the project directory
  - [X] `npm test`
  - [X] `npm run lint`
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have filled out all fields above
