### PR TITLE
Version 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ---
 
+## Version 2.2.0
+
+This release adds a few key features to improve your Dynamoose workflow.
+
+Please comment or [contact me](https://charlie.fish/contact) if you have any questions about this release.
+
+### General
+
+- Added support for `query.sort`
+- Added support for only passing model name into `dynamoose.model` and having it retrieve the registered model that was already registered previously
+- Added support for passing original value into `set` attribute setting function
+- Added attributes setting to `Model.get` to only retrieve certain attributes
+
+### Bug Fixes
+
+- Fixed an issue where `document.original` would return a DynamoDB object and not a parsed object in certain cases
+
+---
+
 ## Version 2.1.3
 
 This release fixes some minor bugs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Dynamoose is a modeling tool for Amazon's DynamoDB (inspired by Mongoose)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Version 2.2.0

This release adds a few key features to improve your Dynamoose workflow.

Please comment or [contact me](https://charlie.fish/contact) if you have any questions about this release.

### General

- Added support for `query.sort`
- Added support for only passing model name into `dynamoose.model` and having it retrieve the registered model that was already registered previously
- Added support for passing original value into `set` attribute setting function
- Added attributes setting to `Model.get` to only retrieve certain attributes

### Bug Fixes

- Fixed an issue where `document.original` would return a DynamoDB object and not a parsed object in certain cases