### PR TITLE
Document.original nested object fix

### DIFF
--- a/lib/Document.ts
+++ b/lib/Document.ts
@@ -29,7 +29,7 @@ export class Document {
 			"configurable": false,
 			"value": {}
 		});
-		this[internalProperties].originalObject = {...documentObject};
+		this[internalProperties].originalObject = JSON.parse(JSON.stringify(documentObject));
 		this[internalProperties].originalSettings = {...settings};
 
 		Object.defineProperty(this, "model", {

--- a/test/Document.js
+++ b/test/Document.js
@@ -1168,11 +1168,18 @@ describe("Document", () => {
 			expect({...document}).to.eql({"id": 2});
 		});
 
+		it("Shouldn't modify inner array after modifying document", () => {
+			const document = new model({"id": {"N": "1"}, "array": {"L": [{"S": "1"}]}}, {"type": "fromDynamo"});
+			document.array.push("2");
+			expect(document.original()).to.eql({"id": 1, "array": ["1"]});
+			expect({...document}).to.eql({"id": 1, "array": ["1", "2"]});
+		});
+
 		it("Shouldn't modify inner object after modifying document", () => {
-			const document = new model({"id": {"N": "1"}, "el": {"L": [{"S": "1"}]}}, {"type": "fromDynamo"});
-			document.el.push("2");
-			expect(document.original()).to.eql({"id": 1, "el": ["1"]});
-			expect({...document}).to.eql({"id": 1, "el": ["1", "2"]});
+			const document = new model({"id": {"N": "1"}, "object": {"M": {"hello": {"S": "world"}}}}, {"type": "fromDynamo"});
+			document.object.test = "item";
+			expect(document.original()).to.eql({"id": 1, "object": {"hello": "world"}});
+			expect({...document}).to.eql({"id": 1, "object": {"hello": "world", "test": "item"}});
 		});
 	});
 

--- a/test/Document.js
+++ b/test/Document.js
@@ -1167,6 +1167,13 @@ describe("Document", () => {
 			expect(document.original()).to.eql({"id": 1});
 			expect({...document}).to.eql({"id": 2});
 		});
+
+		it("Shouldn't modify inner object after modifying document", () => {
+			const document = new model({"id": {"N": "1"}, "el": {"L": [{"S": "1"}]}}, {"type": "fromDynamo"});
+			document.el.push("2");
+			expect(document.original()).to.eql({"id": 1, "el": ["1"]});
+			expect({...document}).to.eql({"id": 1, "el": ["1", "2"]});
+		});
 	});
 
 	describe("document.delete", () => {


### PR DESCRIPTION
### Summary:
Changing Object.Assign to JSON.parse/stringify to properly deep-clone the original object.

### GitHub linked issue:

Closes #922

### Type (select 1):
- [X] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here

### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [X] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [X] Yes
- [ ] No


### Other:
- [X] I have read through and followed the Contributing Guidelines
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [X] I have updated the Dynamoose documentation (if required) given the changes I made
- [X] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [X] I have ensured the following commands are successful from the root of the project directory
  - [X] `npm test`
  - [X] `npm run lint`
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have filled out all fields above
