### PR TITLE
Fixing typings for nested Schemas in Schema Object

### DIFF
--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -249,7 +249,7 @@ interface AttributeDefinitionTypeSettings {
 }
 interface AttributeDefinition {
 	type: AttributeType | {value: DateConstructor; settings?: AttributeDefinitionTypeSettings} | {value: AttributeType}; // TODO add support for this being an object
-	schema?: SchemaDefinition | SchemaDefinition[];
+	schema?: AttributeType | AttributeType[] | AttributeDefinition | AttributeDefinition[] | SchemaDefinition | SchemaDefinition[];
 	default?: ValueType | (() => ValueType);
 	forceDefault?: boolean;
 	validate?: ValueType | RegExp | ((value: ValueType) => boolean);

--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -543,7 +543,7 @@ export class Schema {
 				attributeType = Array.isArray(tmpAttributeType) ? tmpAttributeType : [tmpAttributeType];
 			} catch (e) {} // eslint-disable-line no-empty
 
-			if (attributeType.some((type) => type === "L") && (this.getAttributeValue(key).schema || []).length > 1) {
+			if (attributeType.some((type) => type === "L") && ((this.getAttributeValue(key).schema || []) as any).length > 1) {
 				throw new CustomError.InvalidParameter("You must only pass one element into schema array.");
 			}
 		};

--- a/test/types/Schema.ts
+++ b/test/types/Schema.ts
@@ -1,0 +1,39 @@
+/* eslint @typescript-eslint/no-unused-vars: 0 */
+
+import * as dynamoose from "../../dist";
+
+// @ts-expect-error
+const shouldFailWithNothingPassedIn = new dynamoose.Schema();
+const shouldSucceedWithObjectPassedIn = new dynamoose.Schema({"id": "String"});
+const shouldSucceedWithTypeConstructorPassedIn = new dynamoose.Schema({"id": String});
+
+const shouldSucceedWithNestedSchemaAsConstructor = new dynamoose.Schema({
+	"data": {
+		"type": Array,
+		"schema": [String]
+	}
+});
+const shouldSucceedWithNestedSchemaAsObject = new dynamoose.Schema({
+	"data": {
+		"type": Array,
+		"schema": [
+			{
+				"type": String
+			}
+		]
+	}
+});
+const shouldSucceedWithMultipleNestedSchemas = new dynamoose.Schema({
+	"friends": {
+		"type": Array,
+		"schema": [
+			{
+				"type": Object,
+				"schema": {
+					"zip": Number,
+					"country": String
+				}
+			}
+		]
+	}
+});


### PR DESCRIPTION
### Summary:

This pull request fixes an issue with the TypeScript typings for nested schemas.


### Code sample:
#### Schema
```
const FriendSchema = new Schema({
    friends: {
        type: Array,
        schema: [
            {
                type: Object,
                schema: {
                    zip: Number,
                    country: {
                        type: String,
                        required: true,
                    },
                },
            },
        ],
    },
})
```


### GitHub linked issue:

Closes #854


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
