### PR TITLE
Update returns and schema settings saveUnknown

### DIFF
--- a/lib/Document.ts
+++ b/lib/Document.ts
@@ -315,7 +315,7 @@ Document.objectFromSchema = async function (object: any, model: Model<Document>,
 			}
 		} else {
 			// Check saveUnknown
-			if (!settings.saveUnknown || !utils.dynamoose.wildcard_allowed_check(schema.getSettingValue("saveUnknown"), key)) {
+			if (settings.saveUnknown === false || !utils.dynamoose.wildcard_allowed_check(schema.getSettingValue("saveUnknown"), key)) {
 				keysToDelete.push(key);
 			}
 		}

--- a/test/unit/Document.js
+++ b/test/unit/Document.js
@@ -2558,6 +2558,11 @@ describe("Document", () => {
 				"output": {"id": 1, "data": "hello world"}
 			},
 			{
+				"input": [{"id": 1, "data": "hello world"}, {"customTypesDynamo": true, "checkExpiredItem": true, "type": "fromDynamo"}],
+				"model": ["User", new Schema({"id": Number}, {"saveUnknown": true})],
+				"output": {"id": 1, "data": "hello world"}
+			},
+			{
 				"input": [{"id": 1, "data": true}, {"type": "fromDynamo"}],
 				"schema": () => {
 					const Item = dynamoose.model("Item", {"id": Number, "data": String}, {"create": false, "waitForActive": false});


### PR DESCRIPTION
### Summary:
Hello, We had an issue when using the Document.update feature after updating to version 2.3.
The problem was we had our models set to saveUnknown:true. So when we call the update function, we expect it to return the objects whole.

After some research in in the Document Class I found out that the function `Document.objectFromSchema => checkTypeFunction` was not using the schema setting saveUnknown correctly as the value in the settings was undefined.

I hope you will understand and consider my edits.
Thanks from ShareGroop

### Type (select 1):
- [X] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [ ] No
- [X] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [X] Yes
- [ ] No


### Other:
- [X] I have read through and followed the Contributing Guidelines
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [X] I have updated the Dynamoose documentation (if required) given the changes I made
- [X] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [X] I have ensured the following commands are successful from the root of the project directory
  - [X] `npm test`
  - [X] `npm run lint`
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have filled out all fields above
