### PR TITLE
dynamoose#961 Fix an issue where document.delete fails for rangeKey

### DIFF
--- a/lib/Document.ts
+++ b/lib/Document.ts
@@ -111,9 +111,15 @@ export class Document {
 	delete(this: Document): Promise<void>;
 	delete(this: Document, callback: CallbackType<void, AWSError>): void;
 	delete (this: Document, callback?: CallbackType<void, AWSError>): Promise<void> | void {
-		return this.model.delete({
-			[this.model.getHashKey()]: this[this.model.getHashKey()]
-		}, callback);
+		const hashKey = this.model.getHashKey();
+		const rangeKey = this.model.getRangeKey();
+
+		const options = {[hashKey]: this[hashKey]};
+		if (rangeKey) {
+			options[rangeKey] = this[rangeKey];
+		}
+
+		return this.model.delete(options, callback);
 	}
 
 	// Save

--- a/lib/Document.ts
+++ b/lib/Document.ts
@@ -114,12 +114,12 @@ export class Document {
 		const hashKey = this.model.getHashKey();
 		const rangeKey = this.model.getRangeKey();
 
-		const options = {[hashKey]: this[hashKey]};
+		const key = {[hashKey]: this[hashKey]};
 		if (rangeKey) {
-			options[rangeKey] = this[rangeKey];
+			key[rangeKey] = this[rangeKey];
 		}
 
-		return this.model.delete(options, callback);
+		return this.model.delete(key, callback);
 	}
 
 	// Save

--- a/test/unit/Document.js
+++ b/test/unit/Document.js
@@ -1561,6 +1561,19 @@ describe("Document", () => {
 					});
 				});
 
+				it("Should deleteItem with correct parameters with a range key", async () => {
+					User = dynamoose.model("User", {"id": Number, "name": {"type": String, "rangeKey": true}});
+					user = new User({"id": 1, "name": "Charlie", "type": "admin"});
+
+					deleteItemFunction = () => Promise.resolve();
+					const func = (document) => util.promisify(document.delete);
+					await func(user).bind(user)();
+					expect(deleteParams).to.eql({
+						"Key": {"id": {"N": "1"}, "name": {"S": "Charlie"}},
+						"TableName": "User"
+					});
+				});
+
 				it("Should throw error if DynamoDB API returns an error", () => {
 					deleteItemFunction = () => Promise.reject({"error": "ERROR"});
 					return expect(callType.func(user).bind(user)()).to.be.rejectedWith({"error": "ERROR"});

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -3652,6 +3652,24 @@ describe("Model", () => {
 					});
 				});
 
+				it("Should send correct params to deleteItem if we pass in an entire object with unnecessary attributes with range key", async () => {
+					deleteItemFunction = () => Promise.resolve();
+					User = dynamoose.model("User", {"id": Number, "name": {"type": String, "rangeKey": true}});
+					await callType.func(User).bind(User)({"id": 1, "type": "bar", "name": "Charlie"});
+					expect(deleteItemParams).to.be.an("object");
+					expect(deleteItemParams).to.eql({
+						"Key": {
+							"id": {
+								"N": "1"
+							},
+							"name": {
+								"S": "Charlie"
+							}
+						},
+						"TableName": "User"
+					});
+				});
+
 
 				it("Should return request if return request setting is set", async () => {
 					const result = await callType.func(User).bind(User)(1, {"return": "request"});
@@ -3667,6 +3685,38 @@ describe("Model", () => {
 
 					return expect(callType.func(User).bind(User)({"id": 1, "name": "Charlie"})).to.be.rejectedWith({"error": "ERROR"});
 				});
+			});
+		});
+
+		it("Should send correct params to deleteItem if we pass in an entire object with unnecessary attributes with range key", async () => {
+			deleteItemFunction = () => Promise.resolve();
+
+			const schema = {
+				"PK": {"type": String, "hashKey": true},
+				"SK": {"type": String, "rangeKey": true},
+				"someAttribute": {"type": String}
+			};
+			const ExampleModel = dynamoose.model("TestTable", schema);
+
+			const example = new ExampleModel({
+				"PK": "primarKey",
+				"SK": "sortKey",
+				"someAttribute": "someValue"
+			});
+
+			const func = (Model) => Model.delete;
+			await func(ExampleModel).bind(ExampleModel)(example);
+			expect(deleteItemParams).to.be.an("object");
+			expect(deleteItemParams).to.eql({
+				"Key": {
+					"PK": {
+						"S": "primarKey"
+					},
+					"SK": {
+						"S": "sortKey"
+					}
+				},
+				"TableName": "TestTable"
 			});
 		});
 	});


### PR DESCRIPTION
### Summary:

Issue #961 reported that document.delete() and Model.delete(document) fails for documents with rangeKey.  The underlying cause is that document.delete 


### Code sample:

#### Model
```
User = dynamoose.model("User", {"id": Number, "name": {"type": String, "rangeKey": true}});
```

#### General
```
user = User.get({"id": 1, "name": "Charlie", "type": "admin"});
await user.delete()
```


### GitHub linked issue:
Closes #961 
#---

### Other information:
This change appears to fix two real bugs with `delete` related to rangeKeys.

### Type (select 1):
- [X] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [X] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [X] Yes
- [ ] No


### Other:
- [X] I have read through and followed the Contributing Guidelines
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [X] I have updated the Dynamoose documentation (if required) given the changes I made
- [X] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [X] I have ensured the following commands are successful from the root of the project directory
  - [X] `npm test`
  - [X] `npm run lint`
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have filled out all fields above
