### PR TITLE
dynamoose#984 Add SetContructor to support Schema Sets

### DIFF
--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -224,7 +224,7 @@ const attributeTypes: (DynamoDBTypeResult | DynamoDBSetTypeResult)[] = utils.arr
 type SetValueType = {wrapperName: "Set"; values: ValueType[]; type: string /* TODO: should probably make this an enum */};
 type GeneralValueType = string | boolean | number | Buffer | Date;
 export type ValueType = GeneralValueType | {[key: string]: ValueType} | ValueType[] | SetValueType;
-type AttributeType = string | StringConstructor | BooleanConstructor | NumberConstructor | typeof Buffer | DateConstructor | ObjectConstructor | ArrayConstructor;
+type AttributeType = string | StringConstructor | BooleanConstructor | NumberConstructor | typeof Buffer | DateConstructor | ObjectConstructor | ArrayConstructor | SetConstructor;
 
 export interface TimestampObject {
 	createdAt?: string | string[];

--- a/test/types/Schema.ts
+++ b/test/types/Schema.ts
@@ -37,7 +37,6 @@ const shouldSucceedWithMultipleNestedSchemas = new dynamoose.Schema({
 		]
 	}
 });
-
 const shouldSucceedWithStringSet = new dynamoose.Schema({
 	"data": {
 		"type": Set,

--- a/test/types/Schema.ts
+++ b/test/types/Schema.ts
@@ -37,3 +37,10 @@ const shouldSucceedWithMultipleNestedSchemas = new dynamoose.Schema({
 		]
 	}
 });
+
+const shouldSucceedWithStringSet = new dynamoose.Schema({
+	"data": {
+		"type": Set,
+		"schema": [String]
+	}
+});


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary: 
Currently the type definition is missing `SetConstructor` which results in Type Error not allowing us query for Dynamodb Sets.

<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue: #984 
### Other information:
I'm not sure if there's another issue with Set or not but when I'm using it in my code base I'm noticing that the records returned from the Set are always empty `{}` not sure if it's related to this and even if Set is fully supported within this package.

I see in dynamoose 2.x documentation there's example of using set like the following:

``` js
{
    "friends": {
        "type": Set,
        "schema": [String]
    }
}
```

Currently TSC will complain

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [ ] No
- [x] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [ ] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
