### PR TITLE
fix(model): rangeKey with 0 (Number) value shouldn't be deleted

### DIFF
--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -44,7 +44,7 @@ export interface ModelOptions {
 export type ModelOptionsOptional = Partial<ModelOptions>;
 
 
-type KeyObject = {[attribute: string]: string};
+type KeyObject = {[attribute: string]: string | number};
 type InputKey = string | KeyObject;
 
 // Utility functions
@@ -400,7 +400,7 @@ export class Model<T extends DocumentCarrier = AnyDocument> {
 			keyObject = {
 				[hashKey]: key[hashKey]
 			};
-			if (rangeKey && key[rangeKey]) {
+			if (rangeKey && (key[rangeKey] === 0 || key[rangeKey])) {
 				keyObject[rangeKey] = key[rangeKey];
 			}
 		} else {

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -400,7 +400,7 @@ export class Model<T extends DocumentCarrier = AnyDocument> {
 			keyObject = {
 				[hashKey]: key[hashKey]
 			};
-			if (rangeKey && (key[rangeKey] === 0 || key[rangeKey])) {
+			if (rangeKey && typeof key[rangeKey] !== "undefined" && key[rangeKey] !== null) {
 				keyObject[rangeKey] = key[rangeKey];
 			}
 		} else {

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -3935,6 +3935,16 @@ describe("Model", () => {
 
 				expect(result).to.eql("Dynamoose Warning: Passing callback function into transaction method not allowed. Removing callback function from list of arguments.");
 			});
+
+			it("Should keep range keys with 0 value", async () => {
+				User = dynamoose.model("User", {"id": String, "order": {"type": Number, "rangeKey": true}});
+				expect(await User.transaction.delete({"id": "foo", "order": 0})).to.eql({
+					"Delete": {
+						"Key": {"id": {"S": "foo"}, "order": {"N": "0"}},
+						"TableName": "User"
+					}
+				});
+			});
 		});
 
 		describe("Model.transaction.update", () => {


### PR DESCRIPTION
### Summary:
The issue happens when you have a table with rangeKey of type Number. When you try to delete an item with value `0` it gets stripped out and request fails. In the `cli` it is a completely valid request, which completes successfully:
```sh
myMachine:myProject myName$ aws dynamodb delete-item \
>     --region eu-west-1 \
>     --table-name my-table \
>     --key '{"itemId":{"S":"uni-6d6a2bd6-1d7d-41b0-8c1a-203f2dfe568a"}, "order": {"N": "0"}}'
```

#### Schema
```js
{
  "id": String, 
  "order": {
    "type": Number, 
    "rangeKey": true
  }
}
```

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
