### PR TITLE
#918 Fix for forcing LSI when query possible with table's primary index

### DIFF
--- a/lib/Condition.ts
+++ b/lib/Condition.ts
@@ -10,7 +10,7 @@ const isRawConditionObject = (object): boolean => Object.keys(object).length ===
 export type ConditionFunction = (condition: Condition) => Condition;
 // TODO: There is a problem where you can have multiple keys in one `ConditionStorageType`, which will cause problems. We need to fix that. Likely be refactoring it so that the key is part of `ConditionsConditionStorageObject`.
 type ConditionStorageType = {[key: string]: ConditionsConditionStorageObject} | typeof OR;
-type ConditionStorageTypeNested = ConditionStorageType | Array<ConditionStorageTypeNested>;
+export type ConditionStorageTypeNested = ConditionStorageType | Array<ConditionStorageTypeNested>;
 type ConditionStorageSettingsConditions = ConditionStorageTypeNested[];
 // TODO: the return value of the function below is incorrect. We need to add a property to the object that is a required string, where the property/key name is always equal to `settings.conditionString`
 type ConditionRequestObjectResult = {ExpressionAttributeNames?: DynamoDB.Types.ExpressionAttributeNameMap; ExpressionAttributeValues?: DynamoDB.Types.ExpressionAttributeValueMap};

--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -158,8 +158,7 @@ DocumentRetriever.prototype.getRequest = async function (this: DocumentRetriever
 	}
 	const indexes = await this.internalSettings.model.getIndexes();
 	function canUseIndexOfTable (hashKeyOfTable, rangeKeyOfTable, chart: ConditionStorageTypeNested): boolean {
-		const hashKeyInQuery = Object.entries(chart)
-			.find(([fieldName, {type}]) => type === "EQ" && fieldName === hashKeyOfTable);
+		const hashKeyInQuery = Object.entries(chart).find(([fieldName, {type}]) => type === "EQ" && fieldName === hashKeyOfTable);
 		if (!hashKeyInQuery) {
 			return false;
 		}

--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -166,8 +166,7 @@ DocumentRetriever.prototype.getRequest = async function (this: DocumentRetriever
 		const isOneKeyQuery = Object.keys(chart).length === 1;
 		if (isOneKeyQuery && hashKeyInQuery) {
 			return true;
-		} else {
-			if (rangeKeyOfTable) {
+		} else if (rangeKeyOfTable) {
 				return Object.entries(chart).some(([fieldName]) => fieldName !== hashKeyInQuery[0]);
 			}
 		}

--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -166,8 +166,7 @@ DocumentRetriever.prototype.getRequest = async function (this: DocumentRetriever
 		if (isOneKeyQuery && hashKeyInQuery) {
 			return true;
 		} else if (rangeKeyOfTable) {
-				return Object.entries(chart).some(([fieldName]) => fieldName !== hashKeyInQuery[0]);
-			}
+			return Object.entries(chart).some(([fieldName]) => fieldName !== hashKeyInQuery[0]);
 		}
 		return false;
 	}

--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -168,11 +168,7 @@ DocumentRetriever.prototype.getRequest = async function (this: DocumentRetriever
 			return true;
 		} else {
 			if (rangeKeyOfTable) {
-				const rangeKeyInQuery = Object.entries(chart)
-					.find(([fieldName]) => fieldName !== hashKeyInQuery[0]);
-				if (rangeKeyInQuery) {
-					return true;
-				}
+				return Object.entries(chart).some(([fieldName]) => fieldName !== hashKeyInQuery[0]);
 			}
 		}
 		return false;

--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -181,12 +181,7 @@ DocumentRetriever.prototype.getRequest = async function (this: DocumentRetriever
 			res[myItem[0]] = {"type": myItem[1].type};
 			return res;
 		}, {});
-		const tryToGuessIndex = !canUseIndexOfTable(
-			this.internalSettings.model.getHashKey(),
-			this.internalSettings.model.getRangeKey(),
-			comparisonChart
-		);
-		if (tryToGuessIndex) {
+		if (!canUseIndexOfTable(this.internalSettings.model.getHashKey(), this.internalSettings.model.getRangeKey(), comparisonChart)) {
 			const index = utils.array_flatten(Object.values(indexes)).find((index) => {
 				const {hash/*, range*/} = index.KeySchema.reduce((res, item) => {
 					res[item.KeyType.toLowerCase()] = item.AttributeName;
@@ -196,9 +191,7 @@ DocumentRetriever.prototype.getRequest = async function (this: DocumentRetriever
 				return (comparisonChart[hash] || {}).type === "EQ"/* && (!range || comparisonChart[range])*/;
 			});
 			if (!index) {
-				if ((comparisonChart[this.internalSettings.model.getHashKey()] || {}).type !== "EQ") {
-					throw new CustomError.InvalidParameter("Index can't be found for query.");
-				}
+				throw new CustomError.InvalidParameter("Index can't be found for query.");
 			} else {
 				object.IndexName = index.IndexName;
 			}

--- a/test/unit/Query.js
+++ b/test/unit/Query.js
@@ -730,7 +730,7 @@ describe("Query", () => {
 			});
 		});
 
-		describe("using table's index", () => {
+		describe("using index of table", () => {
 			let LSIModel;
 
 			beforeEach(() => {

--- a/test/unit/Query.js
+++ b/test/unit/Query.js
@@ -730,7 +730,7 @@ describe("Query", () => {
 			});
 		});
 
-		describe("using index of table", () => {
+		describe("Using index of table", () => {
 			let LSIModel;
 
 			beforeEach(() => {


### PR DESCRIPTION
### Summary:
The issue is described in #918. The only thing that bothers me with this fix is that it'll break those queries which currently may fallback to LSI. Someone may not notice that they forgot to mention the LSI name in query and get error. Though should be fine as soon as the index name is set using `using`.

### GitHub linked issue:
Closes #918 

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [x] 🚨 YES 🚨 (if we consider previous behaviour "normal" then yes, otherwise can be considered a bugfix)
- [ ] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
