### PR TITLE
Bug#981 Model.get() should allow reserved keyword attributes

### DIFF
--- a/docs/docs/guide/Model.md
+++ b/docs/docs/guide/Model.md
@@ -165,7 +165,7 @@ You can also pass in an object for the optional `settings` parameter that is an 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
 | return | What the function should return. Can be `document`, or `request`. In the event this is set to `request` the request Dynamoose will make to DynamoDB will be returned, and no request to DynamoDB will be made. If this is `request`, the function will not be async anymore. | String | `document` |
-| attributes | What document attributes should be retrieved & returned. This will use the underlying `ProjectionExpression` DynamoDB option to ensure only the attributes you request will be sent over the wire. If this value is `undefined`, then all attributes will be returned. | [String] | undefined |
+| attributes | What document attributes should be retrieved & returned. This will use the underlying `ProjectionExpression` DynamoDB option to ensure only the attributes you request will be sent over the wire. It also use the underlaying `ExpressionAttributeNames` DynamoDB option to avoid errors with attributes names that conflicts with a DynamoDB reserved word. If this value is `undefined`, then all attributes will be returned. | [String] | undefined |
 | consistent | Whether to perform a strongly consistent read or not. If this value is `undefined`, then no `ConsistentRead` parameter will be included in the request, and DynamoDB will default to an eventually consistent read. | boolean | undefined |
 
 ```js

--- a/docs/docs/guide/Model.md
+++ b/docs/docs/guide/Model.md
@@ -165,7 +165,7 @@ You can also pass in an object for the optional `settings` parameter that is an 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
 | return | What the function should return. Can be `document`, or `request`. In the event this is set to `request` the request Dynamoose will make to DynamoDB will be returned, and no request to DynamoDB will be made. If this is `request`, the function will not be async anymore. | String | `document` |
-| attributes | What document attributes should be retrieved & returned. This will use the underlying `ProjectionExpression` DynamoDB option to ensure only the attributes you request will be sent over the wire. It also use the underlaying `ExpressionAttributeNames` DynamoDB option to avoid errors with attributes names that conflicts with a DynamoDB reserved word. If this value is `undefined`, then all attributes will be returned. | [String] | undefined |
+| attributes | What document attributes should be retrieved & returned. This will use the underlying `ProjectionExpression` DynamoDB option to ensure only the attributes you request will be sent over the wire. If this value is `undefined`, then all attributes will be returned. | [String] | undefined |
 | consistent | Whether to perform a strongly consistent read or not. If this value is `undefined`, then no `ConsistentRead` parameter will be included in the request, and DynamoDB will default to an eventually consistent read. | boolean | undefined |
 
 ```js

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -937,7 +937,8 @@ export class Model<T extends DocumentCarrier = AnyDocument> {
 			getItemParams.ConsistentRead = settings.consistent;
 		}
 		if (settings.attributes) {
-			getItemParams.ProjectionExpression = settings.attributes.join(", ");
+			getItemParams.ProjectionExpression = settings.attributes.map((attribute) => "#" + attribute).join(", ");
+			getItemParams.ExpressionAttributeNames = settings.attributes.reduce((accumulator, currentValue) => (accumulator["#" + currentValue] = currentValue, accumulator), {});
 		}
 		if (settings.return === "request") {
 			if (callback) {

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -937,8 +937,8 @@ export class Model<T extends DocumentCarrier = AnyDocument> {
 			getItemParams.ConsistentRead = settings.consistent;
 		}
 		if (settings.attributes) {
-			getItemParams.ProjectionExpression = settings.attributes.map((attribute) => "#" + attribute).join(", ");
-			getItemParams.ExpressionAttributeNames = settings.attributes.reduce((accumulator, currentValue) => (accumulator["#" + currentValue] = currentValue, accumulator), {});
+			getItemParams.ProjectionExpression = settings.attributes.map((attribute, index) => `#a${index}`).join(", ");
+			getItemParams.ExpressionAttributeNames = settings.attributes.reduce((accumulator, currentValue, index) => (accumulator[`#a${index}`] = currentValue, accumulator), {});
 		}
 		if (settings.return === "request") {
 			if (callback) {

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -1152,7 +1152,10 @@ describe("Model", () => {
 							}
 						},
 						"TableName": "User",
-						"ProjectionExpression": "id"
+						"ProjectionExpression": "#id",
+						"ExpressionAttributeNames": {
+							"#id": "id"
+						}
 					});
 				});
 
@@ -1167,7 +1170,11 @@ describe("Model", () => {
 							}
 						},
 						"TableName": "User",
-						"ProjectionExpression": "id, name"
+						"ProjectionExpression": "#id, #name",
+						"ExpressionAttributeNames": {
+							"#id": "id",
+							"#name": "name"
+						}
 					});
 				});
 

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -1152,9 +1152,9 @@ describe("Model", () => {
 							}
 						},
 						"TableName": "User",
-						"ProjectionExpression": "#id",
+						"ProjectionExpression": "#a0",
 						"ExpressionAttributeNames": {
-							"#id": "id"
+							"#a0": "id"
 						}
 					});
 				});
@@ -1170,10 +1170,10 @@ describe("Model", () => {
 							}
 						},
 						"TableName": "User",
-						"ProjectionExpression": "#id, #name",
+						"ProjectionExpression": "#a0, #a1",
 						"ExpressionAttributeNames": {
-							"#id": "id",
-							"#name": "name"
+							"#a0": "id",
+							"#a1": "name"
 						}
 					});
 				});


### PR DESCRIPTION
### Summary:
Issue #981 reported that Model.get() should allow reserved keyword attributes.
When trying to get a Document with a specific attribute projection, if the projection list has a ["Reserved Word in DynamoDB"](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html), the query fails.

### GitHub linked issue:
Closes #981.

### Other information:
The attributes were set with `ExpressionAttributeNames` and replaced in the `ProjectionExpression`.

### Type (select 1):
- [X] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [X] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [X] Yes
- [ ] No


### Other:
- [X] I have read through and followed the Contributing Guidelines
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [X] I have updated the Dynamoose documentation (if required) given the changes I made
- [X] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [X] I have ensured the following commands are successful from the root of the project directory
  - [X] `npm test`
  - [X] `npm run lint`
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have filled out all fields above
