### PR TITLE
fix: export interface to use typing in scan and query

### DIFF
--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -286,11 +286,11 @@ interface DocumentRetrieverResponse<T> extends DocumentArray<T> {
 	lastKey?: ObjectType;
 	count: number;
 }
-interface ScanResponse<T> extends DocumentRetrieverResponse<T> {
+export interface ScanResponse<T> extends DocumentRetrieverResponse<T> {
 	scannedCount: number;
 	timesScanned: number;
 }
-interface QueryResponse<T> extends DocumentRetrieverResponse<T> {
+export interface QueryResponse<T> extends DocumentRetrieverResponse<T> {
 	queriedCount: number;
 	timesQueried: number;
 }

--- a/test/types/model/Query.ts
+++ b/test/types/model/Query.ts
@@ -14,13 +14,8 @@ async function queryExecUnTyped (): Promise<AnyDocument[]> {
 	return await UserModel.query().exec();
 }
 
-async function queryExecUnTypedQueryResponse (): Promise<QueryResponse<AnyDocument>> {
-	return await UserModel.query().exec();
-}
-
-async function queryExecTyped (): Promise<QueryResponse<User>> {
-	return UserTypedModel.query("name").eq("Will").exec();
-}
+const queryExecUnTypedQueryResponse: Promise<QueryResponse<AnyDocument>> = UserModel.query().exec();
+const queryExecTyped: Promise<QueryResponse<User>> = UserTypedModel.query("name").eq("Will").exec();
 
 // query.limit(count)
 UserTypedModel.query("name").eq("Will").limit(5);

--- a/test/types/model/Query.ts
+++ b/test/types/model/Query.ts
@@ -4,12 +4,17 @@ import {UserTypedModel, UserModel, User} from "../Model";
 import {SortOrder} from "../../../dist/General";
 import {Condition} from "../../../dist";
 import {AnyDocument} from "../../../dist/Document";
+import {QueryResponse} from "../../../dist/DocumentRetriever";
 
 // query.exec([callback])
 async function queryExec (): Promise<User[]> {
 	return await UserTypedModel.query().exec();
 }
 async function queryExecUnTyped (): Promise<AnyDocument[]> {
+	return await UserModel.query().exec();
+}
+
+async function queryExecUnTypedQueryResponse (): Promise<QueryResponse<AnyDocument>> {
 	return await UserModel.query().exec();
 }
 

--- a/test/types/model/Query.ts
+++ b/test/types/model/Query.ts
@@ -18,6 +18,10 @@ async function queryExecUnTypedQueryResponse (): Promise<QueryResponse<AnyDocume
 	return await UserModel.query().exec();
 }
 
+async function queryExecTyped (): Promise<QueryResponse<User>> {
+	return UserTypedModel.query("name").eq("Will").exec();
+}
+
 // query.limit(count)
 UserTypedModel.query("name").eq("Will").limit(5);
 

--- a/test/types/model/Scan.ts
+++ b/test/types/model/Scan.ts
@@ -17,6 +17,10 @@ async function scanExecUnTypedWithScanResponse (): Promise<ScanResponse<AnyDocum
 	return await UserModel.scan().exec();
 }
 
+async function scanExecTyped (): Promise<ScanResponse<User>> {
+	return UserTypedModel.scan("name").eq("Will").exec();
+}
+
 UserTypedModel.scan().exec();
 
 // scan.limit(count)

--- a/test/types/model/Scan.ts
+++ b/test/types/model/Scan.ts
@@ -13,13 +13,8 @@ async function scanExecUnTyped (): Promise<AnyDocument[]> {
 	return await UserModel.scan().exec();
 }
 
-async function scanExecUnTypedWithScanResponse (): Promise<ScanResponse<AnyDocument>> {
-	return await UserModel.scan().exec();
-}
-
-async function scanExecTyped (): Promise<ScanResponse<User>> {
-	return UserTypedModel.scan("name").eq("Will").exec();
-}
+const scanExecUnTypedWithScanResponse: Promise<ScanResponse<AnyDocument>> = UserModel.scan().exec();
+const scanExecTyped: Promise<ScanResponse<User>> = UserTypedModel.scan("name").eq("Will").exec();
 
 UserTypedModel.scan().exec();
 

--- a/test/types/model/Scan.ts
+++ b/test/types/model/Scan.ts
@@ -3,12 +3,17 @@
 import {UserTypedModel, User, UserModel} from "../Model";
 import {Condition} from "../../../dist";
 import {AnyDocument} from "../../../dist/Document";
+import {ScanResponse} from "../../../dist/DocumentRetriever";
 
 // scan.exec([callback])
 async function scanExec (): Promise<User[]> {
 	return await UserTypedModel.scan().exec();
 }
 async function scanExecUnTyped (): Promise<AnyDocument[]> {
+	return await UserModel.scan().exec();
+}
+
+async function scanExecUnTypedWithScanResponse (): Promise<ScanResponse<AnyDocument>> {
 	return await UserModel.scan().exec();
 }
 


### PR DESCRIPTION
### Sumary
export interface to use typing in scan and query
the Scan and Query interfaces that are already exported did not work for me.

```
return Promise<ScanResponse<Api>> => Schema.scan().exec();
return Promise<QueryResponse<IRequestApi>>;
```

### Type (select 1):
- [x ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x ] I have read through and followed the Contributing Guidelines
- [ x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x ] I have ensured the following commands are successful from the root of the project directory
  - [x ] `npm test`
  - [ x] `npm run lint`
- [ x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x ] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [ x] I have filled out all fields above
