### PR TITLE
document.save Condition Support

### DIFF
--- a/docs/docs/guide/Document.md
+++ b/docs/docs/guide/Document.md
@@ -29,6 +29,7 @@ You can also pass a settings object in as the first parameter. The following opt
 |---|---|---|---|
 | overwrite | boolean | true | If an existing document with the same hash key should be overwritten in the database. You can set this to false to not overwrite an existing document with the same hash key. |
 | return | string | `document` | If the function should return the `document` or `request`. If you set this to `request` the request that would be made to DynamoDB will be returned, but no requests will be made to DynamoDB. |
+| condition | [`dynamoose.Condition`](Condition) | `null` | This is an optional instance of a Condition for the save. |
 
 Both `settings` and `callback` parameters are optional. You can pass in a `callback` without `settings`, just by passing in one argument and having that argument be the `callback`. You are not required to pass in `settings` if you just want to pass in a `callback`.
 

--- a/test/unit/Document.js
+++ b/test/unit/Document.js
@@ -1365,6 +1365,47 @@ describe("Document", () => {
 					}]);
 				});
 
+				it("Should save with correct object with condition", async () => {
+					putItemFunction = () => Promise.resolve();
+					User = dynamoose.model("User", {"id": Number, "data1": String}, {"create": false, "waitForActive": false});
+					user = new User({"id": 1, "data1": "hello"});
+					await callType.func(user).bind(user)({"condition": new dynamoose.Condition("breed").eq("Terrier")});
+					expect(putParams).to.eql([{
+						"Item": {"id": {"N": "1"}, "data1": {"S": "hello"}},
+						"ConditionExpression": "#a0 = :v0",
+						"ExpressionAttributeNames": {
+							"#a0": "breed"
+						},
+						"ExpressionAttributeValues": {
+							":v0": {
+								"S": "Terrier"
+							}
+						},
+						"TableName": "User"
+					}]);
+				});
+
+				it("Should save with correct object with condition and overwrite set to false", async () => {
+					putItemFunction = () => Promise.resolve();
+					User = dynamoose.model("User", {"id": Number, "data1": String}, {"create": false, "waitForActive": false});
+					user = new User({"id": 1, "data1": "hello"});
+					await callType.func(user).bind(user)({"condition": new dynamoose.Condition("breed").eq("Terrier"), "overwrite": false});
+					expect(putParams).to.eql([{
+						"Item": {"id": {"N": "1"}, "data1": {"S": "hello"}},
+						"ConditionExpression": "(#a0 = :v0) AND (attribute_not_exists(#__hash_key))",
+						"ExpressionAttributeNames": {
+							"#__hash_key": "id",
+							"#a0": "breed"
+						},
+						"ExpressionAttributeValues": {
+							":v0": {
+								"S": "Terrier"
+							}
+						},
+						"TableName": "User"
+					}]);
+				});
+
 				it("Should throw error if DynamoDB API returns an error", async () => {
 					putItemFunction = () => Promise.reject({"error": "Error"});
 					let result, error;


### PR DESCRIPTION
### Summary:

This PR adds support for a `dynamoose.Condition` setting for `document.save`.


### Code sample:
#### General
```
user.save({
    "condition": new dynamoose.Condition("name").eq("Charlie");
});
```


### GitHub linked issue:
Closes #978 


### Type (select 1):
- [ ] Bug fix
- [x] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
