### PR TITLE
dynamoose.THIS Schema TypeScript Fix

### DIFF
--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -224,7 +224,7 @@ const attributeTypes: (DynamoDBTypeResult | DynamoDBSetTypeResult)[] = utils.arr
 type SetValueType = {wrapperName: "Set"; values: ValueType[]; type: string /* TODO: should probably make this an enum */};
 type GeneralValueType = string | boolean | number | Buffer | Date;
 export type ValueType = GeneralValueType | {[key: string]: ValueType} | ValueType[] | SetValueType;
-type AttributeType = string | StringConstructor | BooleanConstructor | NumberConstructor | typeof Buffer | DateConstructor | ObjectConstructor | ArrayConstructor | SetConstructor;
+type AttributeType = string | StringConstructor | BooleanConstructor | NumberConstructor | typeof Buffer | DateConstructor | ObjectConstructor | ArrayConstructor | SetConstructor | symbol;
 
 export interface TimestampObject {
 	createdAt?: string | string[];

--- a/test/types/Schema.ts
+++ b/test/types/Schema.ts
@@ -43,3 +43,8 @@ const shouldSucceedWithStringSet = new dynamoose.Schema({
 		"schema": [String]
 	}
 });
+const shouldSucceedWithDynamooseThis = new dynamoose.Schema({
+    "id": String,
+    "name": String,
+    "parent": dynamoose.THIS
+});

--- a/test/types/Schema.ts
+++ b/test/types/Schema.ts
@@ -44,7 +44,7 @@ const shouldSucceedWithStringSet = new dynamoose.Schema({
 	}
 });
 const shouldSucceedWithDynamooseThis = new dynamoose.Schema({
-    "id": String,
-    "name": String,
-    "parent": dynamoose.THIS
+	"id": String,
+	"name": String,
+	"parent": dynamoose.THIS
 });


### PR DESCRIPTION
### Summary:

This PR fixes an issue where `dynamoose.THIS` wouldn't work with TypeScript.


<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
new dynamoose.Schema({
	"id": String,
	"name": String,
	"parent": dynamoose.THIS
});
```


### GitHub linked issue:
Closes #1000


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
