### PR TITLE
DynamoDB NULL Property Type Support

### DIFF
--- a/docs/docs/guide/Dynamoose.md
+++ b/docs/docs/guide/Dynamoose.md
@@ -187,3 +187,17 @@ const User = dynamoose.model("User", {"id": String, "parent": dynamoose.THIS});
 :::note
 This property might be used for other things in the future.
 :::
+
+## dynamoose.NULL
+
+Setting a schema attribute to this will cause it to use the DynamoDB `null` type.
+
+```js
+const dynamoose = require("dynamoose");
+
+const User = dynamoose.model("User", {"id": String, "parent": dynamoose.NULL});
+```
+
+:::note
+This property might be used for other things in the future.
+:::

--- a/docs/docs/guide/Schema.md
+++ b/docs/docs/guide/Schema.md
@@ -72,6 +72,7 @@ const schema = new dynamoose.Schema({
 | Date | True | N | True | False | **storage** - miliseconds \| seconds (default: miliseconds) | Will be stored in DynamoDB as milliseconds since Jan 1 1970, and converted to/from a Date instance. |
 | Object | False | M | False | True |   |   |
 | Array | False | L | False | True |   |   |
+| [`dynamoose.NULL`](Dynamoose#dynamoosenull) | False | NULL | False | False |   |   |
 | Schema | False | M | True | True |   | This will be converted to an Object type. |
 | Model | Only if no `rangeKey` for model's schema | S \| N \| B \| M | True | If `rangeKey` in model's schema |   | Model Types are setup a bit differently. [Read below](#model-types) for more information. |
 | Combine | False | S | True | False | **attributes** - [string] - The attributes to store in the combine attribute.\n**seperator** - string (default: `,`) - The string used to seperate the attributes in the combine attribute. | When running `Model.update` you must update all the attributes in the combine attributes array, or none of them. This is to ensure your combine method remains in sync with your overall document. |

--- a/lib/Internal.ts
+++ b/lib/Internal.ts
@@ -4,6 +4,7 @@ export = {
 	},
 	"Public": {
 		"undefined": Symbol("dynamoose.undefined"),
-		"this": Symbol("dynamoose.this")
+		"this": Symbol("dynamoose.this"),
+		"null": Symbol("dynamoose.null")
 	}
 };

--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -149,6 +149,7 @@ const attributeTypesMain: DynamoDBType[] = ((): DynamoDBType[] => {
 	const numberType = new DynamoDBType({"name": "Number", "dynamodbType": "N", "set": true, "jsType": "number"});
 	const stringType = new DynamoDBType({"name": "String", "dynamodbType": "S", "set": true, "jsType": "string"});
 	return [
+		new DynamoDBType({"name": "Null", "dynamodbType": "NULL", "set": false, "jsType": {"func": (val): boolean => val === null}}),
 		new DynamoDBType({"name": "Buffer", "dynamodbType": "B", "set": true, "jsType": Buffer, "customDynamoName": "Binary"}),
 		new DynamoDBType({"name": "Boolean", "dynamodbType": "BOOL", "jsType": "boolean"}),
 		new DynamoDBType({"name": "Array", "dynamodbType": "L", "jsType": {"func": Array.isArray}, "nestedType": true}),
@@ -392,7 +393,7 @@ export class Schema {
 			}
 			const {typeDetails, matchedTypeDetailsIndex, matchedTypeDetailsIndexes} = typeCheckResult;
 			const hasMultipleTypes = Array.isArray(typeDetails);
-			const isObject = typeof value === "object";
+			const isObject = typeof value === "object" && value !== null;
 
 			if (hasMultipleTypes) {
 				if (matchedTypeDetailsIndexes.length > 1 && isObject) {
@@ -591,10 +592,10 @@ export class Schema {
 
 // TODO: in the two functions below I don't think we should be using as. We should try to clean that up.
 Schema.prototype.getHashKey = function (this: Schema): string {
-	return Object.keys(this.schemaObject).find((key) => (this.schemaObject[key] as AttributeDefinition).hashKey) || Object.keys(this.schemaObject)[0];
+	return Object.keys(this.schemaObject).find((key) => (this.schemaObject[key] as AttributeDefinition)?.hashKey) || Object.keys(this.schemaObject)[0];
 };
 Schema.prototype.getRangeKey = function (this: Schema): string | void {
-	return Object.keys(this.schemaObject).find((key) => (this.schemaObject[key] as AttributeDefinition).rangeKey);
+	return Object.keys(this.schemaObject).find((key) => (this.schemaObject[key] as AttributeDefinition)?.rangeKey);
 };
 
 // This function will take in an attribute and value, and throw an error if the property is required and the value is undefined or null.
@@ -730,7 +731,7 @@ function retrieveTypeInfo (type: string, isSet: boolean, key: string, typeSettin
 Schema.prototype.getAttributeTypeDetails = function (this: Schema, key: string, settings: {standardKey?: boolean; typeIndexOptionMap?: {}} = {}): DynamoDBTypeResult | DynamoDBSetTypeResult | DynamoDBTypeResult[] | DynamoDBSetTypeResult[] {
 	const standardKey = settings.standardKey ? key : key.replace(/\.\d+/gu, ".0");
 	const val = this.getAttributeValue(standardKey, {...settings, "standardKey": true});
-	if (!val) {
+	if (typeof val === "undefined") {
 		throw new CustomError.UnknownAttribute(`Invalid Attribute: ${key}`);
 	}
 	let typeVal = typeof val === "object" && !Array.isArray(val) ? val.type : val;
@@ -743,6 +744,7 @@ Schema.prototype.getAttributeTypeDetails = function (this: Schema, key: string, 
 	const getType = (typeVal: AttributeType | AttributeDefinition): string => {
 		let type: string;
 		const isThisType = typeVal as any === Internal.Public.this;
+		const isNullType = typeVal as any === Internal.Public.null;
 		if (typeof typeVal === "function" || isThisType) {
 			if ((typeVal as any).prototype instanceof Document || isThisType) {
 				type = "model";
@@ -762,6 +764,8 @@ Schema.prototype.getAttributeTypeDetails = function (this: Schema, key: string, 
 				const regexFuncName = /^Function ([^(]+)\(/iu;
 				[, type] = typeVal.toString().match(regexFuncName);
 			}
+		} else if (isNullType) {
+			type = "null";
 		} else {
 			type = typeVal as string;
 		}

--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -592,10 +592,10 @@ export class Schema {
 
 // TODO: in the two functions below I don't think we should be using as. We should try to clean that up.
 Schema.prototype.getHashKey = function (this: Schema): string {
-	return Object.keys(this.schemaObject).find((key) => (this.schemaObject[key] as AttributeDefinition)?.hashKey) || Object.keys(this.schemaObject)[0];
+	return Object.keys(this.schemaObject).find((key) => (this.schemaObject[key] as AttributeDefinition).hashKey) || Object.keys(this.schemaObject)[0];
 };
 Schema.prototype.getRangeKey = function (this: Schema): string | void {
-	return Object.keys(this.schemaObject).find((key) => (this.schemaObject[key] as AttributeDefinition)?.rangeKey);
+	return Object.keys(this.schemaObject).find((key) => (this.schemaObject[key] as AttributeDefinition).rangeKey);
 };
 
 // This function will take in an attribute and value, and throw an error if the property is required and the value is undefined or null.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -73,5 +73,6 @@ export = {
 	aws,
 	logger,
 	"UNDEFINED": Internal.Public.undefined,
-	"THIS": Internal.Public.this
+	"THIS": Internal.Public.this,
+	"NULL": Internal.Public.null
 };

--- a/test/unit/Document.js
+++ b/test/unit/Document.js
@@ -1855,6 +1855,14 @@ describe("Document", () => {
 			{
 				"input": {"prop": null},
 				"output": false
+			},
+			{
+				"input": {"prop": {"NULL": true}},
+				"output": true
+			},
+			{
+				"input": {"id": {"S": "foo"}, "data": {"NULL": true}},
+				"output": true
 			}
 		];
 
@@ -1966,6 +1974,16 @@ describe("Document", () => {
 				"input": [{"id": 1, "name": dynamoose.UNDEFINED}, {"defaults": true}],
 				"output": {"id": 1, "name": undefined},
 				"schema": {"id": Number, "name": {"type": String, "default": "Charlie"}}
+			},
+			{
+				"input": [{"id": 1, "data": null}],
+				"output": {"id": 1, "data": null},
+				"schema": {"id": Number, "data": dynamoose.NULL}
+			},
+			{
+				"input": [{"id": 1, "data": null}, {"saveUnknown": true}],
+				"output": {"id": 1, "data": null},
+				"schema": new Schema({"id": Number}, {"saveUnknown": true})
 			},
 			// TODO: uncomment these lines below
 			// {

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -2004,6 +2004,29 @@ describe("Model", () => {
 						"TableName": "User"
 					});
 				});
+
+				it("Should send correct params to putItem with value as null", async () => {
+					const User2 = dynamoose.model("User", {"id": Number, "name": dynamoose.NULL});
+
+					createItemFunction = () => Promise.resolve();
+					await callType.func(User2).bind(User2)({"id": 1, "name": null});
+					expect(createItemParams).to.be.an("object");
+					expect(createItemParams).to.eql({
+						"ConditionExpression": "attribute_not_exists(#__hash_key)",
+						"ExpressionAttributeNames": {
+							"#__hash_key": "id"
+						},
+						"Item": {
+							"id": {
+								"N": "1"
+							},
+							"name": {
+								"NULL": true
+							}
+						},
+						"TableName": "User"
+					});
+				});
 			});
 		});
 	});


### PR DESCRIPTION
### Summary:

This PR adds support for the DynamoDB NULL Property Type.


### Code sample:
#### Schema
```
{"id": String, "parent": dynamoose.NULL}
```


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #951 


### Type (select 1):
- [ ] Bug fix
- [x] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
