### PR TITLE
Make Model.waitForActive.check optional in TypeScript

### DIFF
--- a/docs/docs/guide/Model.md
+++ b/docs/docs/guide/Model.md
@@ -66,8 +66,8 @@ The `config` parameter is an object used to customize settings for the model.
 | waitForActive.check.timeout | How many milliseconds before Dynamoose should timeout and stop checking if the table is active. | Number | 180000 |
 | waitForActive.check.frequency | How many milliseconds Dynamoose should delay between checks to see if the table is active. If this number is set to 0 it will use `setImmediate()` to run the check again. | Number | 1000 |
 | update | If Dynamoose should update the capacity of the existing table to match the model throughput. If this is a boolean of `true` all update actions will be run. If this is an array of strings, only the actions in the array will be run. The array can include the following settings to update, `ttl`, `indexes`, `throughput`. | Boolean \| [String] | false |
-| expires | The setting to describe the time to live for documents created. If you pass in a number it will be used for the `expires.ttl` setting, with default values for everything else. If this is `null`, no time to live will be active on the model. | Number \| Object | null |
-| expires.ttl | The default amount of time the document should stay alive from creation time in milliseconds. | Number | null |
+| expires | The setting to describe the time to live for documents created. If you pass in a number it will be used for the `expires.ttl` setting, with default values for everything else. If this is `undefined`, no time to live will be active on the model. | Number \| Object | undefined |
+| expires.ttl | The default amount of time the document should stay alive from creation time in milliseconds. | Number | undefined |
 | expires.attribute | The attribute name for where the document time to live attribute. | String | `ttl` |
 | expires.items | The options for documents with ttl. | Object | {} |
 | expires.items.returnExpired | If Dynamoose should include expired documents when returning retrieved documents. | Boolean | true |

--- a/lib/General.ts
+++ b/lib/General.ts
@@ -5,6 +5,7 @@ import {Model} from "./Model";
 export type CallbackType<R, E> = (error?: E | null, response?: R) => void;
 export type ObjectType = {[key: string]: any};
 export type FunctionType = (...args: any[]) => any;
+export type DeepPartial<T> = {[P in keyof T]?: DeepPartial<T[P]>};
 
 // - Dynamoose
 interface ModelDocumentConstructor<T extends Document> {

--- a/lib/Model/defaults.ts
+++ b/lib/Model/defaults.ts
@@ -17,7 +17,7 @@ export const original: ModelOptions = {
 	},
 	"update": false,
 	"populate": false,
-	"expires": null
+	"expires": undefined
 	// "streamOptions": {
 	// 	"enabled": false,
 	// 	"type": undefined

--- a/lib/Model/defaults.ts
+++ b/lib/Model/defaults.ts
@@ -16,7 +16,8 @@ export const original: ModelOptions = {
 		}
 	},
 	"update": false,
-	"populate": false
+	"populate": false,
+	"expires": null
 	// "streamOptions": {
 	// 	"enabled": false,
 	// 	"type": undefined

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -7,7 +7,7 @@ import Internal = require("../Internal");
 import {Serializer, SerializerOptions} from "../Serializer";
 import {Condition, ConditionInitalizer} from "../Condition";
 import {Scan, Query} from "../DocumentRetriever";
-import {CallbackType, ObjectType, FunctionType, DocumentArray, ModelType} from "../General";
+import {CallbackType, ObjectType, FunctionType, DocumentArray, ModelType, DeepPartial} from "../General";
 import {custom as customDefaults, original as originalDefaults} from "./defaults";
 import {ModelIndexChangeType} from "../utils/dynamoose/index_changes";
 import {PopulateDocuments} from "../Populate";
@@ -40,9 +40,9 @@ export interface ModelOptions {
 	waitForActive: ModelWaitForActiveSettings;
 	update: boolean | ModelUpdateOptions[];
 	populate: string | string[] | boolean;
-	expires?: number | ModelExpiresSettings;
+	expires: number | ModelExpiresSettings;
 }
-export type ModelOptionsOptional = Partial<ModelOptions>;
+export type ModelOptionsOptional = DeepPartial<ModelOptions>;
 
 
 type KeyObject = {[attribute: string]: string | number};

--- a/test/types/Model.ts
+++ b/test/types/Model.ts
@@ -13,6 +13,8 @@ const shouldSucceedWithOnlyPassingInName = dynamoose.model("User");
 
 const model = dynamoose.model("User");
 
+const shouldSucceedWithWaitForActive = dynamoose.model("User", {"id": String}, {"waitForActive": {"enabled": true}});
+
 // @ts-expect-error
 const shouldFailWithInvalidTransaction = model.transaction.notValid();
 


### PR DESCRIPTION
### Summary:

This PR fixes an issue where `Model.waitForActive.check` was not optional in TypeScript.


### GitHub linked issue:
Closes #911


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
