### PR TITLE
Schema#getIndexAttributes should handle array defined indicies.

### DIFF
--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -613,20 +613,20 @@ Schema.prototype.getIndexAttributes = async function (this: Schema): Promise<{in
 			attribute
 		}))
 	))
-	.filter((obj) => obj.index)
-	.reduce((accumulator, currentValue) => {
-		if (Array.isArray(currentValue.index)) {
-			currentValue.index.forEach((currentIndex) => {
-				accumulator.push({
-					...currentValue,
-					"index": currentIndex
+		.filter((obj) => obj.index)
+		.reduce((accumulator, currentValue) => {
+			if (Array.isArray(currentValue.index)) {
+				currentValue.index.forEach((currentIndex) => {
+					accumulator.push({
+						...currentValue,
+						"index": currentIndex
+					});
 				});
-			});
-		} else {
-			accumulator.push(currentValue);
-		}
-		return accumulator;
-	}, []);
+			} else {
+				accumulator.push(currentValue);
+			}
+			return accumulator;
+		}, []);
 };
 Schema.prototype.getIndexRangeKeyAttributes = async function (this: Schema): Promise<{attribute: string}[]> {
 	const indexes: ({index: IndexDefinition; attribute: string})[] = await this.getIndexAttributes();

--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -613,20 +613,20 @@ Schema.prototype.getIndexAttributes = async function (this: Schema): Promise<{in
 			attribute
 		}))
 	))
-		.filter((obj) => obj.index)
-		.reduce((accumulator, currentValue) => {
-			if (Array.isArray(currentValue.index)) {
-				currentValue.index.forEach((currentIndex) => {
-					accumulator.push({
-						...currentValue,
-						"index": currentIndex
-					});
+	.filter((obj) => obj.index)
+	.reduce((accumulator, currentValue) => {
+		if (Array.isArray(currentValue.index)) {
+			currentValue.index.forEach((currentIndex) => {
+				accumulator.push({
+					...currentValue,
+					"index": currentIndex
 				});
-			} else {
-				accumulator.push(currentValue);
-			}
-			return accumulator;
-		}, []);
+			});
+		} else {
+			accumulator.push(currentValue);
+		}
+		return accumulator;
+	}, []);
 };
 Schema.prototype.getIndexRangeKeyAttributes = async function (this: Schema): Promise<{attribute: string}[]> {
 	const indexes: ({index: IndexDefinition; attribute: string})[] = await this.getIndexAttributes();

--- a/test/unit/Schema.js
+++ b/test/unit/Schema.js
@@ -1158,7 +1158,6 @@ describe("Schema", () => {
 
 	describe("getIndexAttributes", () => {
 		const tests = [
-			// Defaults
 			{
 				"name": "Should return an empty array if no indicies are defined",
 				"schema": {"id": String},
@@ -1195,13 +1194,7 @@ describe("Schema", () => {
 			it(test.name, async () => {
 				const schema = new dynamoose.Schema(test.schema);
 				const output = await schema.getIndexAttributes();
-				if (typeof output !== "function") {
-					expect(output).to.eql(test.output);
-				} else {
-					expect(typeof output).to.eql(typeof test.output);
-					expect(output.toString()).to.eql(test.output.toString());
-					expect(await output()).to.eql(await test.output());
-				}
+				expect(output).to.eql(test.output);
 			});
 		});
 	});

--- a/test/unit/Schema.js
+++ b/test/unit/Schema.js
@@ -961,6 +961,7 @@ describe("Schema", () => {
 			expect(result.map((item) => ({"name": item.name, "dynamodbType": item.dynamodbType}))).to.eql([{"name": "String", "dynamodbType": "S"}, {"name": "Buffer", "dynamodbType": "B"}]);
 		});
 	});
+
 	describe("getAttributeSettingValue", () => {
 		const tests = [
 			// Defaults
@@ -1204,7 +1205,6 @@ describe("Schema", () => {
 			});
 		});
 	});
-
 
 	describe("getTypePaths", () => {
 		it("Should be a function", () => {


### PR DESCRIPTION
### Summary:

This fixes a bug where trying to define an array of indexes on an attribute [_per the documentation_]( https://dynamoosejs.com/guide/Schema#index-boolean--object--array) didn't yield the correct index definitions.

This will enshrine support for the following example (adapted from the current documentation).

### Code sample:
#### Schema
```
{
    "id": {
        "hashKey": true,
        "type": String,
        "index": [
                {
                    "name": "emailIndex",
                    "rangeKey": "email",
                    "throughput": {"read": 5, "write": 10}
                }, // creates a local secondary index with the name `emailIndex`, hashKey `id`, rangeKey `email`
        ]
    },
    "email": {
        "type": String
    }
}
```

### Type (select 1):
- [x] Bug fix


### Is this a breaking change? (select 1):
- [x] No


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
