### PR TITLE
Prioritize indexes with correct range key when querying

### DIFF
--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -193,7 +193,7 @@ DocumentRetriever.prototype.getRequest = async function (this: DocumentRetriever
 				})
 				.filter((index) => comparisonChart[index._hashKey]?.type === "EQ");
 
-			const index = validIndexes.find((index) => !!comparisonChart[index._rangeKey]) || validIndexes[0];
+			const index = validIndexes.find((index) => comparisonChart[index._rangeKey]) || validIndexes[0];
 
 			if (!index) {
 				throw new CustomError.InvalidParameter("Index can't be found for query.");

--- a/test/unit/Query.js
+++ b/test/unit/Query.js
@@ -295,11 +295,11 @@ describe("Query", () => {
 
 				it("Should send correct request on query.exec using array of indexes", async () => {
 					queryPromiseResolver = () => ({"Items": []});
-					Model = dynamoose.model("Cat", {"id": String, "name": {"type": String, "index": [{"global": true, "rangeKey": "age", "name": "AgeIndex"}, {"global": true, "rangeKey": "breed", "name": "BreedIndex"}]}, "age": Number, "breed": String});
+					Model = dynamoose.model("Cat", {"id": String, "name": {"type": String, "index": [{"global": true, "rangeKey": "age", "name": "NameAgeIndex"}, {"global": true, "rangeKey": "breed", "name": "NameBreedIndex"}]}, "age": Number, "breed": String});
 					await callType.func(Model.query("name").eq("Charlie").where("age").gt(10).exec).bind(Model.query("name").eq("Charlie").where("age").gt(10))();
 					expect(queryParams).to.eql({
 						"TableName": "Cat",
-						"IndexName": "AgeIndex",
+						"IndexName": "NameAgeIndex",
 						"ExpressionAttributeNames": {
 							"#qha": "name",
 							"#qra": "age"
@@ -314,7 +314,7 @@ describe("Query", () => {
 					await callType.func(Model.query("name").eq("Charlie").where("breed").eq("calico").exec).bind(Model.query("name").eq("Charlie").where("breed").eq("calico"))();
 					expect(queryParams).to.eql({
 						"TableName": "Cat",
-						"IndexName": "BreedIndex",
+						"IndexName": "NameBreedIndex",
 						"ExpressionAttributeNames": {
 							"#qha": "name",
 							"#qra": "breed"
@@ -324,6 +324,26 @@ describe("Query", () => {
 							":qrv": {"S": "calico"}
 						},
 						"KeyConditionExpression": "#qha = :qhv AND #qra = :qrv"
+					});
+				});
+
+				it("Should send correct request on query.exec using array of indexes and unknown range key", async () => {
+					queryPromiseResolver = () => ({"Items": []});
+					Model = dynamoose.model("Cat", {"id": String, "name": {"type": String, "index": [{"global": true, "name": "NameIndex"}, {"global": true, "rangeKey": "age", "name": "NameAgeIndex"}]}, "age": Number, "breed": String});
+					await callType.func(Model.query("name").eq("Charlie").where("breed").eq("calico").exec).bind(Model.query("name").eq("Charlie").where("breed").eq("calico"))();
+					expect(queryParams).to.eql({
+						"TableName": "Cat",
+						"IndexName": "NameIndex",
+						"ExpressionAttributeNames": {
+							"#qha": "name",
+							"#a1": "breed"
+						},
+						"ExpressionAttributeValues": {
+							":qhv": {"S": "Charlie"},
+							":v1": {"S": "calico"}
+						},
+						"KeyConditionExpression": "#qha = :qhv",
+						"FilterExpression": "#a1 = :v1"
 					});
 				});
 


### PR DESCRIPTION
### Summary:

Currently, Dynamoose only considers `hashKey` when choosing the index to use. If two indexes exist with the same `hashKey` (and different `rangeKey`), only the first will be used.

This PR resolves this issue by including `rangeKey` when considering which index to use. If no index exists for both the given `hashKey` and `rangeKey`, the current behavior (selecting the first index on the `hashKey`) is used.

<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
// ...
    secondaryHash: {
      type: String,
      index: [
        {
          global: true,
          rangeKey: 'secondaryRange1',
        },
        {
          global: true,
          rangeKey: 'secondaryRange2',
        },
      ],
    }
// ...
```

Currently querying on `secondaryRange1` will give us:

```
{
  ExpressionAttributeNames: { '#qha': 'secondaryHash', '#qra': 'secondaryRange1' },
  ExpressionAttributeValues: { ':qhv': { S: 'test1' }, ':qrv': { N: '1' } },
  TableName: 'users-prod',
  IndexName: 'ExampleIndex1',
  KeyConditionExpression: '#qha = :qhv AND #qra = :qrv'
}
```

And querying on `secondaryRange2` will give us:

```
{
  ExpressionAttributeNames: { '#qha': 'secondaryHash', '#qra': 'secondaryRange1' },
  ExpressionAttributeValues: { ':qhv': { S: 'test1' }, ':qrv': { N: '1' } },
  TableName: 'users-prod',
  IndexName: 'ExampleIndex1',
  KeyConditionExpression: '#qha = :qhv AND #qra = :qrv'
}
```

This query is incorrect, and should use `ExampleIndex2` instead of `ExampleIndex1`! After this PR, a query on `secondaryRange2` would resolve in the following:

```
{
  ExpressionAttributeNames: { '#qha': 'secondaryHash', '#qra': 'secondaryRange2' },
  ExpressionAttributeValues: { ':qhv': { S: 'test1' }, ':qrv': { N: '1' } },
  TableName: 'users-prod',
  IndexName: 'ExampleIndex2',
  KeyConditionExpression: '#qha = :qhv AND #qra = :qrv'
}
```

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
