### PR TITLE
Returned saved document

### DIFF
--- a/lib/Document.ts
+++ b/lib/Document.ts
@@ -140,8 +140,11 @@ export class Document {
 			settings = {};
 		}
 
+		let savedItem;
+
 		const localSettings: DocumentSaveSettings = settings;
 		const paramsPromise = this.toDynamo({"defaults": true, "validate": true, "required": true, "enum": true, "forceDefault": true, "combine": true, "saveUnknown": true, "customTypesDynamo": true, "updateTimestamps": true, "modifiers": ["set"]}).then((item) => {
+			savedItem = item;
 			let putItemObj: DynamoDB.PutItemInput = {
 				"Item": item,
 				"TableName": this.model.name
@@ -182,13 +185,22 @@ export class Document {
 		if (callback) {
 			const localCallback: CallbackType<Document, AWSError> = callback as CallbackType<Document, AWSError>;
 			promise.then(() => {
-				this[internalProperties].storedInDynamo = true; localCallback(null, this);
+				this[internalProperties].storedInDynamo = true;
+
+				const returnDocument = new this.model.Document(savedItem as any);
+				returnDocument[internalProperties].storedInDynamo = true;
+
+				localCallback(null, returnDocument);
 			}).catch((error) => callback(error));
 		} else {
 			return (async (): Promise<Document> => {
 				await promise;
 				this[internalProperties].storedInDynamo = true;
-				return this;
+
+				const returnDocument = new this.model.Document(savedItem as any);
+				returnDocument[internalProperties].storedInDynamo = true;
+
+				return returnDocument;
 			})();
 		}
 	}

--- a/test/unit/Document.js
+++ b/test/unit/Document.js
@@ -170,6 +170,16 @@ describe("Document", () => {
 					expect(result).to.eql(user);
 				});
 
+				it("Should return correct result after saving with defaults", async () => {
+					putItemFunction = () => Promise.resolve();
+
+					User = dynamoose.model("User", {"id": Number, "name": String, "defaultValue": {"type": String, "default": "Hello World"}});
+					user = new User({"id": 1, "name": "Charlie"});
+
+					const result = await callType.func(user).bind(user)();
+					expect(result.toJSON()).to.eql({"id": 1, "name": "Charlie", "defaultValue": "Hello World"});
+				});
+
 				it("Should return request if return request is set as setting", async () => {
 					const result = await callType.func(user).bind(user)({"return": "request"});
 					expect(putParams).to.eql([]);

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -1878,6 +1878,15 @@ describe("Model", () => {
 		];
 		functionCallTypes.forEach((callType) => {
 			describe(callType.name, () => {
+				it("Should return correct result after saving with defaults", async () => {
+					createItemFunction = () => Promise.resolve();
+
+					User = dynamoose.model("User", {"id": Number, "name": String, "defaultValue": {"type": String, "default": "Hello World"}});
+
+					const result = await callType.func(User).bind(User)({"id": 1, "name": "Charlie"});
+					expect(result.toJSON()).to.eql({"id": 1, "name": "Charlie", "defaultValue": "Hello World"});
+				});
+
 				it("Should send correct params to putItem", async () => {
 					createItemFunction = () => Promise.resolve();
 					await callType.func(User).bind(User)({"id": 1, "name": "Charlie"});


### PR DESCRIPTION
### Summary:

This PR changes the behavior to return the saved document instead of document passed in for `Model.create` and `document.save`.


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #1135


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [ ] No
- [x] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
