### PR TITLE
Null type error message improvements

### DIFF
--- a/lib/Document.ts
+++ b/lib/Document.ts
@@ -335,7 +335,7 @@ Document.objectFromSchema = async function (object: any, model: Model<Document>,
 		if (existsInSchema) {
 			const {isValidType, matchedTypeDetails, typeDetailsArray} = utils.dynamoose.getValueTypeCheckResult(schema, value, genericKey, settings, {"standardKey": true, typeIndexOptionMap});
 			if (!isValidType) {
-				throw new Error.TypeMismatch(`Expected ${key} to be of type ${typeDetailsArray.map((detail) => detail.dynamicName ? detail.dynamicName() : detail.name.toLowerCase()).join(", ")}, instead found type ${typeof value}${typeDetailsArray.some((val) => val.name === "Constant") ? ` (${value})` : ""}.`);
+				throw new Error.TypeMismatch(`Expected ${key} to be of type ${typeDetailsArray.map((detail) => detail.dynamicName ? detail.dynamicName() : detail.name.toLowerCase()).join(", ")}, instead found type ${utils.type_name(value, typeDetailsArray)}.`);
 			} else if (matchedTypeDetails.isSet || matchedTypeDetails.name.toLowerCase() === "model") {
 				validParents.push({key, "infinite": true});
 			} else if (/*typeDetails.dynamodbType === "M" || */matchedTypeDetails.dynamodbType === "L") {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -9,6 +9,7 @@ import empty_function = require("./empty_function");
 import object = require("./object");
 import dynamoose = require("./dynamoose");
 import all_elements_match from "./all_elements_match";
+import type_name from "./type_name";
 
 export = {
 	combine_objects,
@@ -21,5 +22,6 @@ export = {
 	array_flatten,
 	empty_function,
 	object,
-	dynamoose
+	dynamoose,
+	type_name
 };

--- a/lib/utils/type_name.ts
+++ b/lib/utils/type_name.ts
@@ -2,5 +2,15 @@ import { DynamoDBSetTypeResult, DynamoDBTypeResult } from "../Schema";
 
 // This function takes in a value and returns a user string for the type of that value. This function is mostly used to display type errors to users.
 export default (value: any, typeDetailsArray: (DynamoDBTypeResult | DynamoDBSetTypeResult)[]): string => {
-	return `${typeof value}${typeDetailsArray.some((val) => val.name === "Constant") ? ` (${value})` : ""}`;
+	let str: string = "";
+	if (value === null) {
+		str += "null";
+	} else {
+		str += typeof value;
+	}
+
+	// Add constant value to type name
+	str += typeDetailsArray.some((val) => val.name === "Constant") ? ` (${value})` : "";
+
+	return str;
 };

--- a/lib/utils/type_name.ts
+++ b/lib/utils/type_name.ts
@@ -1,0 +1,6 @@
+import { DynamoDBSetTypeResult, DynamoDBTypeResult } from "../Schema";
+
+// This function takes in a value and returns a user string for the type of that value. This function is mostly used to display type errors to users.
+export default (value: any, typeDetailsArray: (DynamoDBTypeResult | DynamoDBSetTypeResult)[]): string => {
+	return `${typeof value}${typeDetailsArray.some((val) => val.name === "Constant") ? ` (${value})` : ""}`;
+};

--- a/lib/utils/type_name.ts
+++ b/lib/utils/type_name.ts
@@ -1,8 +1,8 @@
-import { DynamoDBSetTypeResult, DynamoDBTypeResult } from "../Schema";
+import {DynamoDBSetTypeResult, DynamoDBTypeResult} from "../Schema";
 
 // This function takes in a value and returns a user string for the type of that value. This function is mostly used to display type errors to users.
 export default (value: any, typeDetailsArray: (DynamoDBTypeResult | DynamoDBSetTypeResult)[]): string => {
-	let str: string = "";
+	let str = "";
 	if (value === null) {
 		str += "null";
 	} else {

--- a/test/unit/Document.js
+++ b/test/unit/Document.js
@@ -2750,6 +2750,11 @@ describe("Document", () => {
 					return {"id": Number, "data": [{"type": Set, "schema": [Item]}, String]};
 				},
 				"error": new Error.ValidationError("Expected data to be of type Item Set, string, instead found type boolean.")
+			},
+			{
+				"input": [{"id": 1, "data": null}, {"type": "toDynamo"}],
+				"schema": {"id": Number, "data": String},
+				"error": new Error.ValidationError("Expected data to be of type string, instead found type null.")
 			}
 		];
 


### PR DESCRIPTION
### Summary:

Using `null` for type errors when `null` value provided instead of `object`.


### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #1077 


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
