### PR TITLE
Version 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ---
 
+## Version 2.7.2
+
+This release fixes a bug related to the return value of `document.save` and `Model.create`, and more.
+
+Please comment or [contact me](https://charlie.fish/contact) if you have any questions about this release.
+
+### Bug Fixes
+
+- `document.save` & `Model.create` now return the document saved to DynamoDB
+- Type messages now display `null` when passing in a invalid type `null` value as opposed to the previous `object`
+
+### Other
+
+- Added some more TypeScript tests
+
+---
+
 ## Version 2.7.1
 
 This release has a lot of bug fixes for Dynamoose.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Below you will find the current branch strategy for the project. Work taking pla
 | --- | --- | --- | --- |
 | [`v3`](https://github.com/dynamoose/dynamoose/tree/v3) | 3.0.0 | alpha | - [Documentation](https://dynamoose-git-v3-dynamoose.vercel.app/) |
 | [`master`](https://github.com/dynamoose/dynamoose/tree/master) | 2.7.x |   | - [Documentation](https://dynamoose.now.sh/) |
-| [`v2.7.1` (tag)](https://github.com/dynamoose/dynamoose/tree/v2.7.1) | 2.7.1 | latest | - [Documentation](https://dynamoosejs.com)
+| [`v2.7.2` (tag)](https://github.com/dynamoose/dynamoose/tree/v2.7.2) | 2.7.2 | latest | - [Documentation](https://dynamoosejs.com)
+
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Dynamoose is a modeling tool for Amazon's DynamoDB (inspired by Mongoose)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Version 2.7.2

This release fixes a bug related to the return value of `document.save` and `Model.create`, and more.

Please comment or [contact me](https://charlie.fish/contact) if you have any questions about this release.

### Bug Fixes

- `document.save` & `Model.create` now return the document saved to DynamoDB
- Type messages now display `null` when passing in a invalid type `null` value as opposed to the previous `object`

### Other

- Added some more TypeScript tests