### PR TITLE
Query.sort TypeScript Improvement

### DIFF
--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -34,7 +34,7 @@ abstract class DocumentRetriever {
 		consistent?: boolean;
 		count?: boolean;
 		parallel?: number;
-		sort?: SortOrder;
+		sort?: SortOrder | `${SortOrder}`;
 	};
 	getRequest: (this: DocumentRetriever) => Promise<any>;
 	all: (this: DocumentRetriever, delay?: number, max?: number) => DocumentRetriever;
@@ -328,7 +328,7 @@ export class Query<T> extends DocumentRetriever {
 		return super.exec(callback);
 	}
 
-	sort (order: SortOrder): Query<T> {
+	sort (order: SortOrder | `${SortOrder}`): Query<T> {
 		this.settings.sort = order;
 		return this;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.7.2",
+      "version": "2.7.3",
       "funding": [
         {
           "type": "github-sponsors",
@@ -34,7 +34,7 @@
         "mocha": "^7.2.0",
         "nyc": "^15.1.0",
         "rimraf": "^3.0.2",
-        "typescript": "^4.0.5"
+        "typescript": "^4.3.5"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -3836,7 +3836,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.0.5",
+      "version": "4.3.5",
+      "resolved": "http://npm.network.charlie.fish/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6548,7 +6550,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.5",
+      "version": "4.3.5",
+      "resolved": "http://npm.network.charlie.fish/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "uri-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2485,7 +2485,7 @@
     },
     "node_modules/js-object-utilities": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.com/js-object-utilities/-/js-object-utilities-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-object-utilities/-/js-object-utilities-2.0.0.tgz",
       "integrity": "sha512-d0o5Hnd+9q9mswk8VhU9Fzl+QLce3FvtNlLKV7UTUYjAZuChAKeS/DnuameOpiJAXquqrXLJYUcABxhIWogwpA==",
       "license": "UNLICENSE"
     },
@@ -3837,7 +3837,7 @@
     },
     "node_modules/typescript": {
       "version": "4.3.5",
-      "resolved": "http://npm.network.charlie.fish/typescript/-/typescript-4.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -5679,7 +5679,7 @@
     },
     "js-object-utilities": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.com/js-object-utilities/-/js-object-utilities-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-object-utilities/-/js-object-utilities-2.0.0.tgz",
       "integrity": "sha512-d0o5Hnd+9q9mswk8VhU9Fzl+QLce3FvtNlLKV7UTUYjAZuChAKeS/DnuameOpiJAXquqrXLJYUcABxhIWogwpA=="
     },
     "js-tokens": {
@@ -6551,7 +6551,7 @@
     },
     "typescript": {
       "version": "4.3.5",
-      "resolved": "http://npm.network.charlie.fish/typescript/-/typescript-4.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mocha": "^7.2.0",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.0.5"
+    "typescript": "^4.3.5"
   },
   "scripts": {
     "prepare": "npm run build:clean && npm run build",

--- a/test/types/model/Query.ts
+++ b/test/types/model/Query.ts
@@ -44,6 +44,8 @@ UserTypedModel.query("name").eq("Will").using("name-index");
 // query.sort(order)
 UserTypedModel.query("name").eq("Will").sort(SortOrder.ascending);
 UserTypedModel.query("name").eq("Will").sort(SortOrder.descending);
+UserTypedModel.query("name").eq("Will").sort("ascending");
+UserTypedModel.query("name").eq("Will").sort("descending");
 
 // query.all([delay[, max]])
 UserTypedModel.query("name").eq("Will").all();


### PR DESCRIPTION
### Summary:

This PR fixes a TypeScript issue where passing a string into the Query.sort method would throw a TypeScript error.


<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:

#### General
```
Cat.query({ test: 1 }).sort("descending").limit(10).exec()
```


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #1223 


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
