### PR TITLE
Fix "Index can't be found for query." error for a query without an index

### DIFF
--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -167,9 +167,6 @@ DocumentRetriever.prototype.getRequest = async function (this: DocumentRetriever
 		}, {});
 		if (!utils.can_use_index_of_table(this.internalSettings.model.getHashKey(), this.internalSettings.model.getRangeKey(), comparisonChart)) {
 			object.IndexName = utils.find_best_index(indexes, comparisonChart);
-			if (!object.IndexName) {
-				throw new CustomError.InvalidParameter("Index can't be found for query.");
-			}
 		}
 	}
 	function moveParameterNames (val, prefix): void {

--- a/test/unit/Query.js
+++ b/test/unit/Query.js
@@ -800,6 +800,14 @@ describe("Query", () => {
 					});
 				});
 
+				it("Should not throw error if query contains hash key and additional filter expression", () => {
+					queryPromiseResolver = () => ({"Items": []});
+					Model = dynamoose.model("Cat", new dynamoose.Schema({"id": {"type": Number, "hashKey": true}, "name": String}));
+
+					return expect(callType.func(Model.query("id").eq(111).filter("name").eq("Charlie").exec).bind(
+						Model.query("id").eq(111).filter("name").eq("Charlie"))()).to.not.be.rejectedWith("Index can't be found for query.");
+				});
+
 				it("Should throw error if no indexes exist on model", () => {
 					queryPromiseResolver = () => ({"Items": []});
 					Model = dynamoose.model("Cat", new dynamoose.Schema({"id": Number, "name": String}));


### PR DESCRIPTION
### Summary:

Query with a hash key condition and a filter expression without an index should not fail with "Index can't be found for query." error message because it's a valid query in DynamoDB. 
Automatic detection of an index is a nice feature, but it should not limit the functionality of DynamoDB. So a check for an index should be removed or as another possible solution, there should be a setting to disable this behavior.



<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Model
```
const ExampleModel = dynamoose.model(
  "example", {
    "id": {
      "hashKey": true,
      "type": Number,
    },
    "name": {
      "type": String,
    },
   ...   
  });
```

#### General
```
// Should not fail
const response = await ExampleModel.query("id").eq(111).filter("name").eq("Charlie").exec()
```

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [ ] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [ ] Yes
- [x] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [ ] I have ensured the following commands are successful from the root of the project directory
  - [ ] `npm test`
  - [ ] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
