### PR TITLE
Model.update fails when required updating field is prefixing another

### DIFF
--- a/lib/Document.ts
+++ b/lib/Document.ts
@@ -468,7 +468,7 @@ Document.objectFromSchema = async function (object: any, model: Model<Document>,
 	if (settings.required) {
 		let attributesToCheck = await Document.attributesWithSchema(returnObject, model);
 		if (settings.required === "nested") {
-			attributesToCheck = attributesToCheck.filter((attribute) => utils.object.keys(returnObject).find((key) => attribute.startsWith(key)));
+			attributesToCheck = attributesToCheck.filter((attribute) => utils.object.keys(returnObject).find((key) => attribute === key || attribute.startsWith(key + ".")));
 		}
 		await Promise.all(attributesToCheck.map(async (key) => {
 			const check = async (): Promise<void> => {

--- a/test/unit/Document.js
+++ b/test/unit/Document.js
@@ -2052,6 +2052,12 @@ describe("Document", () => {
 				"error": new Error.TypeMismatch("Expected id to be of type number, instead found type string."),
 				"schema": {"id": Number}
 			},
+			{
+				// https://github.com/dynamoose/dynamoose/issues/1212
+				"input": [{"someField": "hello"}, {"validate": true, "enum": true, "forceDefault": true, "required": "nested", "modifiers": ["set"]}],
+				"output": {"someField": "hello"},
+				"schema": {"someField": {"type": String, "required": true}, "someFieldAndMore": {"type": String, "required": true}}
+			},
 			// Defaults
 			{
 				"input": {},


### PR DESCRIPTION
### Summary:

This PR fixes an issue where doing `Model.update` with two attributes that have the same beginning key, it will fail if they are both required.


<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
{
  someField: {
    type: string
    required: true
  },
  someFieldAndMore: {
    type: string,
    required: true
  }
}
```

#### General
```
Model.update({"someField": "hello world"})
```


### GitHub linked issue:
Closes #1212


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
