### PR TITLE
Fixing bugs related to passing value in for key parameter

### DIFF
--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -46,7 +46,7 @@ export type ModelOptionsOptional = DeepPartial<ModelOptions>;
 
 
 type KeyObject = {[attribute: string]: string | number};
-type InputKey = string | KeyObject;
+type InputKey = string | number | KeyObject;
 
 // Transactions
 type GetTransactionResult = Promise<GetTransactionInput>;

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -673,6 +673,14 @@ export class Model<T extends DocumentCarrier = AnyDocument> {
 	// Update
 	update (obj: Partial<T>): Promise<T>;
 	update (obj: Partial<T>, callback: CallbackType<T, AWSError>): void;
+	update (keyObj: InputKey, updateObj: Partial<T>): Promise<T>;
+	update (keyObj: InputKey, updateObj: Partial<T>, callback: CallbackType<T, AWSError>): void;
+	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "request"}): Promise<DynamoDB.UpdateItemInput>;
+	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "request"}, callback: CallbackType<DynamoDB.UpdateItemInput, AWSError>): void;
+	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings): Promise<T>;
+	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings, callback: CallbackType<T, AWSError>): void;
+	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "document"}): Promise<T>;
+	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "document"}, callback: CallbackType<T, AWSError>): void;
 	update (keyObj: ObjectType, updateObj: Partial<T>): Promise<T>;
 	update (keyObj: ObjectType, updateObj: Partial<T>, callback: CallbackType<T, AWSError>): void;
 	update (keyObj: ObjectType, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "request"}): Promise<DynamoDB.UpdateItemInput>;
@@ -681,7 +689,7 @@ export class Model<T extends DocumentCarrier = AnyDocument> {
 	update (keyObj: ObjectType, updateObj: Partial<T>, settings: ModelUpdateSettings, callback: CallbackType<T, AWSError>): void;
 	update (keyObj: ObjectType, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "document"}): Promise<T>;
 	update (keyObj: ObjectType, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "document"}, callback: CallbackType<T, AWSError>): void;
-	update (keyObj: ObjectType, updateObj?: Partial<T> | CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>, settings?: ModelUpdateSettings | CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>, callback?: CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>): void | Promise<T> | Promise<DynamoDB.UpdateItemInput> {
+	update (keyObj: InputKey | ObjectType, updateObj?: Partial<T> | CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>, settings?: ModelUpdateSettings | CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>, callback?: CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>): void | Promise<T> | Promise<DynamoDB.UpdateItemInput> {
 		if (typeof updateObj === "function") {
 			callback = updateObj as CallbackType<DocumentCarrier | DynamoDB.UpdateItemInput, AWSError>; // TODO: fix this, for some reason `updateObj` has a type of Function which is forcing us to type cast it
 			updateObj = null;

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -905,7 +905,7 @@ export class Model<T extends DocumentCarrier = AnyDocument> {
 		const documentify = (document): Promise<any> => new this.Document(document, {"type": "fromDynamo"}).conformToSchema({"customTypesDynamo": true, "checkExpiredItem": true, "type": "fromDynamo", "saveUnknown": true});
 		const localSettings: ModelUpdateSettings = settings;
 		const updateItemParamsPromise: Promise<DynamoDB.UpdateItemInput> = this.pendingTaskPromise().then(async () => ({
-			"Key": this.Document.objectToDynamo(keyObj),
+			"Key": this.Document.objectToDynamo(this.convertObjectToKey(keyObj)),
 			"ReturnValues": localSettings.returnValues || "ALL_NEW",
 			...utils.merge_objects.main({"combineMethod": "object_combine"})(localSettings.condition ? localSettings.condition.requestObject({"index": {"start": index, "set": (i): void => {
 				index = i;

--- a/test/types/Model.ts
+++ b/test/types/Model.ts
@@ -33,6 +33,12 @@ const shouldPassBatchDeleteWithNoReturnSettingCallback = model.batchDelete([{"id
 const shouldPassUpdateWithDefaultReturnValuesSetting = model.update({"id": 1}, {"attributes": ["something"]}, {"returnValues": "ALL_NEW"});
 const shouldPassUpdateWithCustomReturnValuesSetting = model.update({"id": 1}, {"attributes": ["something"]}, {"returnValues": "NONE"});
 
+const shouldPassGetWithStringAsKey = model.get("id");
+const shouldPassGetWithNumberAsKey = model.get(1);
+
+const shouldPassUpdateWithStringAsKey = model.update("id", {"value": "hello world"});
+const shouldPassUpdateWithNumberAsKey = model.update(1, {"value": "hello world"});
+
 const shouldSucceedWithWaitForActiveAsObject = dynamoose.model("User", {"id": String}, {"waitForActive": {"enabled": true}});
 const shouldSucceedWithWaitForActiveSetToFalse = dynamoose.model("User", {"id": String}, {"waitForActive": false});
 const shouldSucceedWithWaitForActiveSetToTrue = dynamoose.model("User", {"id": String}, {"waitForActive": true});

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -2572,6 +2572,54 @@ describe("Model", () => {
 					});
 				});
 
+				it("Should send correct params to updateItem for trying to pass string as key", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					await callType.func(User).bind(User)("id", {"name": "Charlie", "random": "hello world"});
+					expect(updateItemParams).to.be.an("object");
+					expect(updateItemParams).to.eql({
+						"ExpressionAttributeNames": {
+							"#a0": "name"
+						},
+						"ExpressionAttributeValues": {
+							":v0": {
+								"S": "Charlie"
+							}
+						},
+						"UpdateExpression": "SET #a0 = :v0",
+						"Key": {
+							"id": {
+								"S": "id"
+							}
+						},
+						"TableName": "User",
+						"ReturnValues": "ALL_NEW"
+					});
+				});
+
+				it("Should send correct params to updateItem for trying to pass number as key", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					await callType.func(User).bind(User)(1, {"name": "Charlie", "random": "hello world"});
+					expect(updateItemParams).to.be.an("object");
+					expect(updateItemParams).to.eql({
+						"ExpressionAttributeNames": {
+							"#a0": "name"
+						},
+						"ExpressionAttributeValues": {
+							":v0": {
+								"S": "Charlie"
+							}
+						},
+						"UpdateExpression": "SET #a0 = :v0",
+						"Key": {
+							"id": {
+								"N": "1"
+							}
+						},
+						"TableName": "User",
+						"ReturnValues": "ALL_NEW"
+					});
+				});
+
 				it("Should send correct params to updateItem for trying to update unknown list properties with saveUnknown", async () => {
 					updateItemFunction = () => Promise.resolve({});
 					User = dynamoose.model("User", new dynamoose.Schema({"id": Number, "name": String, "age": Number}, {"saveUnknown": true}));


### PR DESCRIPTION
### Summary:

- Fixing issue in TypeScript where you couldn't pass a number value in for a key parameter
- Fixing bug where passing string or number in for Model.update would throw an error


### GitHub linked issue:
Closes #1216


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
