### PR TITLE
Remove `.promise()` method call on AWS SDK call

### DIFF
--- a/lib/aws/ddb/internal.ts
+++ b/lib/aws/ddb/internal.ts
@@ -27,7 +27,7 @@ async function main (method: "transactWriteItems", params: DynamoDB.TransactWrit
 
 async function main (method: string, params: any): Promise<any> {
 	utils.log({"level": "debug", "category": `aws:dynamodb:${method}:request`, "message": JSON.stringify(params, null, 4), "payload": {"request": params}});
-	const result = await ddb()[method](params).promise();
+	const result = await ddb()[method](params);
 	utils.log({"level": "debug", "category": `aws:dynamodb:${method}:response`, "message": typeof result === "undefined" ? "undefined" : JSON.stringify(result, null, 4), "payload": {"response": result}});
 	return result;
 }

--- a/test/unit/Document.js
+++ b/test/unit/Document.js
@@ -100,7 +100,7 @@ describe("Item", () => {
 			aws.ddb.set({
 				"putItem": (params) => {
 					putParams.push(params);
-					return {"promise": putItemFunction};
+					return putItemFunction();
 				}
 			});
 			User = dynamoose.model("User", {"id": Number, "name": String});
@@ -1201,11 +1201,9 @@ describe("Item", () => {
 					aws.ddb.set({
 						"putItem": (params) => {
 							putParams.push(params);
-							return {"promise": putItemFunction};
+							return putItemFunction();
 						},
-						"getItem": () => ({
-							"promise": () => Promise.resolve({"Item": {"id": {"N": "1"}, "name": {"S": "Charlie-set"}}})
-						})
+						"getItem": () => Promise.resolve({"Item": {"id": {"N": "1"}, "name": {"S": "Charlie-set"}}})
 					});
 
 					putItemFunction = () => Promise.resolve();
@@ -1439,12 +1437,10 @@ describe("Item", () => {
 						"Table": {"TableStatus": "CREATING"}
 					};
 					aws.ddb.set({
-						"describeTable": () => ({
-							"promise": () => Promise.resolve(describeTableResponse)
-						}),
+						"describeTable": () => Promise.resolve(describeTableResponse),
 						"putItem": (params) => {
 							putParams.push(params);
-							return {"promise": putItemFunction};
+							return putItemFunction();
 						}
 					});
 					const model = dynamoose.model("User2", {"id": Number, "name": String}, {"waitForActive": {"enabled": true, "check": {"frequency": 0, "timeout": 100}}});
@@ -1579,7 +1575,7 @@ describe("Item", () => {
 			aws.ddb.set({
 				"deleteItem": (params) => {
 					deleteParams = params;
-					return {"promise": deleteItemFunction};
+					return deleteItemFunction();
 				}
 			});
 			User = dynamoose.model("User", {"id": Number, "name": String});
@@ -1644,7 +1640,7 @@ describe("Item", () => {
 			aws.ddb.set({
 				"getItem": (params) => {
 					getItemParams.push(params);
-					return {"promise": getItemFunction};
+					return getItemFunction();
 				}
 			});
 			User = dynamoose.model("User", {"id": Number, "name": String});

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -2090,7 +2090,7 @@ describe("Model", () => {
 			dynamoose.aws.ddb.set({
 				"putItem": (params) => {
 					createItemParams = params;
-					return createItemFunction
+					return createItemFunction;
 				}
 			});
 		});

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -2090,7 +2090,7 @@ describe("Model", () => {
 			dynamoose.aws.ddb.set({
 				"putItem": (params) => {
 					createItemParams = params;
-					return createItemFunction;
+					return createItemFunction();
 				}
 			});
 		});

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -98,20 +98,18 @@ describe("Model", () => {
 			const itemsCalled = [];
 			dynamoose.aws.ddb.set({
 				"createTable": () => {
-					return {
-						"promise": () => new Promise((resolve) => {
-							itemsCalled.push("createTable");
-							setTimeout(() => {
-								itemsCalled.push("createTableDone");
-								resolve();
-							}, 100);
-						})
-					};
+					return new Promise((resolve) => {
+						itemsCalled.push("createTable");
+						setTimeout(() => {
+							itemsCalled.push("createTableDone");
+							resolve();
+						}, 100);
+					});
 				},
-				"describeTable": () => ({"promise": () => {
+				"describeTable": () => {
 					itemsCalled.push("describeTable");
 					return itemsCalled.includes("createTableDone") ? Promise.resolve({"Table": {"TableStatus": "ACTIVE"}}) : Promise.reject();
-				}})
+				}
 			});
 
 			const tableName = "Cat";
@@ -170,9 +168,7 @@ describe("Model", () => {
 					"Table": {"TableStatus": "CREATING"}
 				};
 				dynamoose.aws.ddb.set({
-					"describeTable": () => ({
-						"promise": () => Promise.resolve(describeTableResponse)
-					})
+					"describeTable": () => Promise.resolve(describeTableResponse)
 				});
 				const model = dynamoose.model("Cat", {"id": String}, {"waitForActive": {"enabled": true, "check": {"frequency": 0}}});
 				await utils.set_immediate_promise();
@@ -217,11 +213,9 @@ describe("Model", () => {
 				dynamoose.aws.ddb.set({
 					"createTable": (params) => {
 						createTableParams = params;
-						return {
-							"promise": () => Promise.resolve()
-						};
+						return Promise.resolve();
 					},
-					"describeTable": () => ({"promise": () => Promise.resolve()})
+					"describeTable": () => Promise.resolve()
 				});
 			});
 			afterEach(() => {
@@ -330,11 +324,9 @@ describe("Model", () => {
 				dynamoose.aws.ddb.set({
 					"createTable": (params) => {
 						createTableParams = params;
-						return {
-							"promise": () => Promise.resolve()
-						};
+						return Promise.resolve();
 					},
-					"describeTable": () => ({"promise": () => Promise.resolve({"Table": {"TableStatus": "ACTIVE"}})})
+					"describeTable": () => Promise.resolve({"Table": {"TableStatus": "ACTIVE"}})
 				});
 
 				const tableName = "Cat";
@@ -354,21 +346,15 @@ describe("Model", () => {
 				dynamoose.aws.ddb.set({
 					"createTable": (params) => {
 						createTableParams = params;
-						return {
-							"promise": function () {
-								self = this;
-								return Promise.resolve();
-							}
-						};
+						self = this;
+						return Promise.resolve();
 					},
-					"describeTable": () => ({"promise": () => Promise.resolve()})
+					"describeTable": () => Promise.resolve()
 				});
 
 				dynamoose.model("Cat", {"id": String});
 				await utils.set_immediate_promise();
 				expect(self).to.be.an("object");
-				expect(Object.keys(self)).to.eql(["promise"]);
-				expect(self.promise).to.exist;
 			});
 		});
 
@@ -392,15 +378,11 @@ describe("Model", () => {
 				dynamoose.aws.ddb.set({
 					"describeTable": (params) => {
 						describeTableParams.push(params);
-						return {
-							"promise": () => describeTableFunction(params)
-						};
+						return describeTableFunction(params);
 					},
 					"updateTable": (params) => {
 						updateTableParams.push(params);
-						return {
-							"promise": () => Promise.resolve()
-						};
+						return Promise.resolve();
 					}
 				});
 			});
@@ -533,15 +515,11 @@ describe("Model", () => {
 				updateTableParams = [];
 				dynamoose.aws.ddb.set({
 					"describeTable": () => {
-						return {
-							"promise": describeTableFunction
-						};
+						return describeTableFunction();
 					},
 					"updateTable": (params) => {
 						updateTableParams.push(params);
-						return {
-							"promise": () => Promise.resolve()
-						};
+						return Promise.resolve();
 					}
 				});
 			});
@@ -985,28 +963,22 @@ describe("Model", () => {
 				updateTTLParams = [];
 				dynamoose.aws.ddb.set({
 					"describeTable": () => {
-						return {
-							"promise": () => Promise.resolve({
-								"Table": {
-									"ProvisionedThroughput": {
-										"ReadCapacityUnits": 1,
-										"WriteCapacityUnits": 1
-									},
-									"TableStatus": "ACTIVE"
-								}
-							})
-						};
+						return Promise.resolve({
+							"Table": {
+								"ProvisionedThroughput": {
+									"ReadCapacityUnits": 1,
+									"WriteCapacityUnits": 1
+								},
+								"TableStatus": "ACTIVE"
+							}
+						});
 					},
 					"updateTimeToLive": (params) => {
 						updateTTLParams.push(params);
-						return {
-							"promise": () => Promise.resolve()
-						};
+						return Promise.resolve();
 					},
 					"describeTimeToLive": () => {
-						return describeTTLFunction ? describeTTLFunction() : {
-							"promise": () => Promise.resolve(describeTTL)
-						};
+						return describeTTLFunction ? describeTTLFunction() : Promise.resolve(describeTTL);
 					}
 				});
 			});
@@ -1050,13 +1022,9 @@ describe("Model", () => {
 			it("Should call updateTimeToLive with correct parameters for custom attribute if TTL is disabling", async () => {
 				const startTime = Date.now();
 				let timesCalledDescribeTTL = 0;
-				describeTTLFunction = () => {
-					return {
-						"promise": async () => {
-							timesCalledDescribeTTL++;
-							return Promise.resolve(timesCalledDescribeTTL < 2 ? {"TimeToLiveDescription": {"TimeToLiveStatus": "DISABLING"}} : {"TimeToLiveDescription": {"TimeToLiveStatus": "DISABLED"}});
-						}
-					};
+				describeTTLFunction = async () => {
+					timesCalledDescribeTTL++;
+					return Promise.resolve(timesCalledDescribeTTL < 2 ? {"TimeToLiveDescription": {"TimeToLiveStatus": "DISABLING"}} : {"TimeToLiveDescription": {"TimeToLiveStatus": "DISABLED"}});
 				};
 				const tableName = "Cat";
 				const model = dynamoose.model(tableName, {"id": String}, {"expires": {"ttl": 1000, "attribute": "expires"}});
@@ -1104,7 +1072,7 @@ describe("Model", () => {
 			dynamoose.aws.ddb.set({
 				"getItem": (params) => {
 					getItemParams = params;
-					return {"promise": getItemFunction};
+					return getItemFunction();
 				}
 			});
 		});
@@ -1546,7 +1514,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1565,7 +1533,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1584,7 +1552,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1603,7 +1571,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1622,7 +1590,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1640,7 +1608,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1658,7 +1626,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1676,7 +1644,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1694,7 +1662,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1713,7 +1681,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1732,7 +1700,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1751,7 +1719,7 @@ describe("Model", () => {
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
 								getItemTimesCalled++;
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1767,7 +1735,7 @@ describe("Model", () => {
 						User = dynamoose.model("User", {"id": Number, "name": String, "parent": dynamoose.THIS}, {"populate": "*"});
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
-								return {"promise": () => params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}}};
+								return params.Key.id.N === "1" ? {"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}} : {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							}
 						});
 						const user = await callType.func(User).bind(User)(1);
@@ -1831,12 +1799,8 @@ describe("Model", () => {
 						"Table": {"TableStatus": "CREATING"}
 					};
 					dynamoose.aws.ddb.set({
-						"describeTable": () => ({
-							"promise": () => Promise.resolve(describeTableResponse)
-						}),
-						"getItem": () => ({
-							"promise": getItemFunction
-						})
+						"describeTable": () => Promise.resolve(describeTableResponse),
+						"getItem": getItemFunction
 					});
 					const model = dynamoose.model("User", {"id": Number, "name": String}, {"waitForActive": {"enabled": true, "check": {"frequency": 0, "timeout": 100}}});
 					await utils.set_immediate_promise();
@@ -1870,7 +1834,7 @@ describe("Model", () => {
 			dynamoose.aws.ddb.set({
 				"batchGetItem": (paramsB) => {
 					params = paramsB;
-					return {"promise": promiseFunction};
+					return promiseFunction();
 				}
 			});
 		});
@@ -2040,10 +2004,10 @@ describe("Model", () => {
 						User = dynamoose.model("User", {"id": Number, "name": String, "parent": dynamoose.THIS}, {"populate": "*"});
 						dynamoose.aws.ddb.set({
 							"getItem": () => {
-								return {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})};
+								return {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							},
 							"batchGetItem": () => {
-								return {"promise": () => ({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]}, "UnprocessedKeys": {}})};
+								return {"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]}, "UnprocessedKeys": {}};
 							}
 						});
 						const result = await callType.func(User).bind(User)([1]);
@@ -2093,12 +2057,8 @@ describe("Model", () => {
 						"Table": {"TableStatus": "CREATING"}
 					};
 					dynamoose.aws.ddb.set({
-						"describeTable": () => ({
-							"promise": () => Promise.resolve(describeTableResponse)
-						}),
-						"batchGetItem": () => ({
-							"promise": promiseFunction
-						})
+						"describeTable": () => Promise.resolve(describeTableResponse),
+						"batchGetItem": promiseFunction
 					});
 					const model = dynamoose.model("User", {"id": Number, "name": String}, {"waitForActive": {"enabled": true, "check": {"frequency": 0, "timeout": 100}}});
 					await utils.set_immediate_promise();
@@ -2130,7 +2090,7 @@ describe("Model", () => {
 			dynamoose.aws.ddb.set({
 				"putItem": (params) => {
 					createItemParams = params;
-					return {"promise": createItemFunction};
+					return createItemFunction
 				}
 			});
 		});
@@ -2350,7 +2310,7 @@ describe("Model", () => {
 			dynamoose.aws.ddb.set({
 				"batchWriteItem": (paramsB) => {
 					params = paramsB;
-					return {"promise": promiseFunction};
+					return promiseFunction();
 				}
 			});
 		});
@@ -2477,7 +2437,7 @@ describe("Model", () => {
 			dynamoose.aws.ddb.set({
 				"updateItem": (params) => {
 					updateItemParams = params;
-					return {"promise": updateItemFunction};
+					return updateItemFunction();
 				}
 			});
 		});
@@ -4176,7 +4136,7 @@ describe("Model", () => {
 			dynamoose.aws.ddb.set({
 				"deleteItem": (params) => {
 					deleteItemParams = params;
-					return {"promise": deleteItemFunction};
+					return deleteItemFunction();
 				}
 			});
 		});
@@ -4351,7 +4311,7 @@ describe("Model", () => {
 			dynamoose.aws.ddb.set({
 				"batchWriteItem": (paramsB) => {
 					params = paramsB;
-					return {"promise": promiseFunction};
+					return promiseFunction();
 				}
 			});
 		});

--- a/test/unit/Populate.js
+++ b/test/unit/Populate.js
@@ -55,7 +55,7 @@ describe("Populate", () => {
 					beforeEach(() => {
 						dynamoose.aws.ddb.set({
 							"getItem": (param) => {
-								return {"promise": () => promiseFunction(param)};
+								return promiseFunction(param);
 							}
 						});
 					});

--- a/test/unit/Query.js
+++ b/test/unit/Query.js
@@ -20,7 +20,7 @@ describe("Query", () => {
 		dynamoose.aws.ddb.set({
 			"query": (request) => {
 				queryParams = request;
-				return {"promise": queryPromiseResolver};
+				return queryPromiseResolver();
 			}
 		});
 	});
@@ -618,10 +618,10 @@ describe("Query", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": dynamoose.THIS});
 						dynamoose.aws.ddb.set({
 							"getItem": () => {
-								return {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})};
+								return {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							},
 							"query": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]};
 							}
 						});
 						const result = await callType.func(Model.query("name").eq("Charlie").exec).bind(Model.query("name").eq("Charlie"))();
@@ -646,10 +646,10 @@ describe("Query", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": Model2});
 						dynamoose.aws.ddb.set({
 							"getItem": () => {
-								return {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})};
+								return {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							},
 							"query": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]};
 							}
 						});
 						const result = await callType.func(Model.query("name").eq("Charlie").exec).bind(Model.query("name").eq("Charlie"))();
@@ -674,10 +674,10 @@ describe("Query", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": {"type": Array, "schema": [Model2]}});
 						dynamoose.aws.ddb.set({
 							"getItem": () => {
-								return {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})};
+								return {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							},
 							"query": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}]};
 							}
 						});
 						const result = await callType.func(Model.query("name").eq("Charlie").exec).bind(Model.query("name").eq("Charlie"))();
@@ -702,10 +702,10 @@ describe("Query", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": {"type": Array, "schema": [Model2]}});
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
-								return params.Key.id.N === "2" ? {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})} : {"promise": () => ({"Item": {"id": {"N": "3"}, "name": {"S": "Tim"}}})};
+								return params.Key.id.N === "2" ? {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}} : {"Item": {"id": {"N": "3"}, "name": {"S": "Tim"}}};
 							},
 							"query": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}, {"N": "3"}]}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}, {"N": "3"}]}}]};
 							}
 						});
 						const result = await callType.func(Model.query("name").eq("Charlie").exec).bind(Model.query("name").eq("Charlie"))();
@@ -733,10 +733,10 @@ describe("Query", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": {"type": Set, "schema": [Model2]}});
 						dynamoose.aws.ddb.set({
 							"getItem": () => {
-								return {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})};
+								return {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							},
 							"query": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}]};
 							}
 						});
 						const result = await callType.func(Model.query("name").eq("Charlie").exec).bind(Model.query("name").eq("Charlie"))();
@@ -758,10 +758,10 @@ describe("Query", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": {"type": Set, "schema": [Model2]}});
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
-								return params.Key.id.N === "2" ? {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})} : {"promise": () => ({"Item": {"id": {"N": "3"}, "name": {"S": "Tim"}}})};
+								return params.Key.id.N === "2" ? {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}} : {"Item": {"id": {"N": "3"}, "name": {"S": "Tim"}}};
 							},
 							"query": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2", "3"]}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2", "3"]}}]};
 							}
 						});
 						const result = await callType.func(Model.query("name").eq("Charlie").exec).bind(Model.query("name").eq("Charlie"))();
@@ -783,10 +783,10 @@ describe("Query", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": dynamoose.THIS}, {"populate": "*"});
 						dynamoose.aws.ddb.set({
 							"getItem": () => {
-								return {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})};
+								return {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							},
 							"query": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]};
 							}
 						});
 						const result = await callType.func(Model.query("name").eq("Charlie").exec).bind(Model.query("name").eq("Charlie"))();

--- a/test/unit/Scan.js
+++ b/test/unit/Scan.js
@@ -20,7 +20,7 @@ describe("Scan", () => {
 		dynamoose.aws.ddb.set({
 			"scan": (request) => {
 				scanParams = request;
-				return {"promise": scanPromiseResolver};
+				return scanPromiseResolver();
 			}
 		});
 	});
@@ -290,10 +290,10 @@ describe("Scan", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": dynamoose.THIS});
 						dynamoose.aws.ddb.set({
 							"getItem": () => {
-								return {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})};
+								return {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							},
 							"scan": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]};
 							}
 						});
 						const result = await callType.func(Model.scan("name").eq("Charlie").exec).bind(Model.scan("name").eq("Charlie"))();
@@ -318,10 +318,10 @@ describe("Scan", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": Model2});
 						dynamoose.aws.ddb.set({
 							"getItem": () => {
-								return {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})};
+								return {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							},
 							"scan": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]};
 							}
 						});
 						const result = await callType.func(Model.scan("name").eq("Charlie").exec).bind(Model.scan("name").eq("Charlie"))();
@@ -346,10 +346,10 @@ describe("Scan", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": {"type": Array, "schema": [Model2]}});
 						dynamoose.aws.ddb.set({
 							"getItem": () => {
-								return {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})};
+								return {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							},
 							"scan": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}]}}]};
 							}
 						});
 						const result = await callType.func(Model.scan("name").eq("Charlie").exec).bind(Model.scan("name").eq("Charlie"))();
@@ -374,10 +374,10 @@ describe("Scan", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": {"type": Array, "schema": [Model2]}});
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
-								return params.Key.id.N === "2" ? {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})} : {"promise": () => ({"Item": {"id": {"N": "3"}, "name": {"S": "Tim"}}})};
+								return params.Key.id.N === "2" ? {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}} : {"Item": {"id": {"N": "3"}, "name": {"S": "Tim"}}};
 							},
 							"scan": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}, {"N": "3"}]}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"L": [{"N": "2"}, {"N": "3"}]}}]};
 							}
 						});
 						const result = await callType.func(Model.scan("name").eq("Charlie").exec).bind(Model.scan("name").eq("Charlie"))();
@@ -405,10 +405,10 @@ describe("Scan", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": {"type": Set, "schema": [Model2]}});
 						dynamoose.aws.ddb.set({
 							"getItem": () => {
-								return {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})};
+								return {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							},
 							"scan": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2"]}}]};
 							}
 						});
 						const result = await callType.func(Model.scan("name").eq("Charlie").exec).bind(Model.scan("name").eq("Charlie"))();
@@ -430,10 +430,10 @@ describe("Scan", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}, "parent": {"type": Set, "schema": [Model2]}});
 						dynamoose.aws.ddb.set({
 							"getItem": (params) => {
-								return params.Key.id.N === "2" ? {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})} : {"promise": () => ({"Item": {"id": {"N": "3"}, "name": {"S": "Tim"}}})};
+								return params.Key.id.N === "2" ? {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}} : {"Item": {"id": {"N": "3"}, "name": {"S": "Tim"}}};
 							},
 							"scan": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2", "3"]}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"NS": ["2", "3"]}}]};
 							}
 						});
 						const result = await callType.func(Model.scan("name").eq("Charlie").exec).bind(Model.scan("name").eq("Charlie"))();
@@ -455,10 +455,10 @@ describe("Scan", () => {
 						Model = dynamoose.model("Cat", {"id": Number, "name": String, "parent": dynamoose.THIS}, {"populate": "*"});
 						dynamoose.aws.ddb.set({
 							"getItem": () => {
-								return {"promise": () => ({"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}})};
+								return {"Item": {"id": {"N": "2"}, "name": {"S": "Bob"}}};
 							},
 							"scan": () => {
-								return {"promise": () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]})};
+								return {"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "parent": {"N": "2"}}]};
 							}
 						});
 						const result = await callType.func(Model.scan().exec).bind(Model.scan())();

--- a/test/unit/Transaction.js
+++ b/test/unit/Transaction.js
@@ -66,7 +66,7 @@ describe("Transaction", () => {
 				dynamoose.aws.ddb.set({
 					"transactGetItems": (params) => {
 						transactParams = params;
-						return () => Promise.resolve({});
+						return Promise.resolve({});
 					}
 				});
 
@@ -100,7 +100,7 @@ describe("Transaction", () => {
 				dynamoose.aws.ddb.set({
 					"transactWriteItems": (params) => {
 						transactParams = params;
-						return () => Promise.resolve({});
+						return Promise.resolve({});
 					}
 				});
 
@@ -157,7 +157,7 @@ describe("Transaction", () => {
 				dynamoose.aws.ddb.set({
 					"transactWriteItems": (params) => {
 						transactParams = params;
-						return () => Promise.resolve({});
+						return Promise.resolve({});
 					}
 				});
 
@@ -172,7 +172,7 @@ describe("Transaction", () => {
 				dynamoose.aws.ddb.set({
 					"transactGetItems": (params) => {
 						transactParams = params;
-						return () => Promise.resolve({});
+						return Promise.resolve({});
 					}
 				});
 

--- a/test/unit/Transaction.js
+++ b/test/unit/Transaction.js
@@ -66,9 +66,7 @@ describe("Transaction", () => {
 				dynamoose.aws.ddb.set({
 					"transactGetItems": (params) => {
 						transactParams = params;
-						return {
-							"promise": () => Promise.resolve({})
-						};
+						return () => Promise.resolve({});
 					}
 				});
 
@@ -102,9 +100,7 @@ describe("Transaction", () => {
 				dynamoose.aws.ddb.set({
 					"transactWriteItems": (params) => {
 						transactParams = params;
-						return {
-							"promise": () => Promise.resolve({})
-						};
+						return () => Promise.resolve({});
 					}
 				});
 
@@ -135,9 +131,7 @@ describe("Transaction", () => {
 
 			it("Should use correct response from AWS", () => {
 				dynamoose.aws.ddb.set({
-					"transactGetItems": () => ({
-						"promise": () => Promise.resolve({"Responses": [{"Item": {"id": {"N": "1"}, "name": {"S": "Bob"}}}, {"Item": {"id": {"N": "2"}, "name": {"S": "My Credit"}}}]})
-					})
+					"transactGetItems": () => Promise.resolve({"Responses": [{"Item": {"id": {"N": "1"}, "name": {"S": "Bob"}}}, {"Item": {"id": {"N": "2"}, "name": {"S": "My Credit"}}}]})
 				});
 
 				dynamoose.model("User", {"id": Number, "name": String});
@@ -150,9 +144,7 @@ describe("Transaction", () => {
 
 			it("Should return null if no response from AWS", () => {
 				dynamoose.aws.ddb.set({
-					"transactGetItems": () => ({
-						"promise": () => Promise.resolve({})
-					})
+					"transactGetItems": () => Promise.resolve({})
 				});
 
 				dynamoose.model("User", {"id": Number, "name": String});
@@ -165,9 +157,7 @@ describe("Transaction", () => {
 				dynamoose.aws.ddb.set({
 					"transactWriteItems": (params) => {
 						transactParams = params;
-						return {
-							"promise": () => Promise.resolve({})
-						};
+						return () => Promise.resolve({});
 					}
 				});
 
@@ -182,9 +172,7 @@ describe("Transaction", () => {
 				dynamoose.aws.ddb.set({
 					"transactGetItems": (params) => {
 						transactParams = params;
-						return {
-							"promise": () => Promise.resolve({})
-						};
+						return () => Promise.resolve({});
 					}
 				});
 


### PR DESCRIPTION
### Summary:

The new Dynamo SDK returns a promise, as opposed to needing to call `.promise()` on a method call. I had a little go running with the `alpha` release but couldn't get even the simplest example working, I'd reliably get `.promise` is not a function. I feel like I must have missed something here, or be doing something wrong, but if not here is the fix for the problem I was facing.

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [ ] No
- [x] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] `yarn test` wasn't passing for me before my change.
- [ ] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [ ] `npm test` wasn't passing for me before my change.
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
