### PR TITLE
Deep copy object passed to update

### DIFF
--- a/lib/Document.ts
+++ b/lib/Document.ts
@@ -33,7 +33,7 @@ export class Document {
 			"configurable": false,
 			"value": {}
 		});
-		this[internalProperties].originalObject = JSON.parse(JSON.stringify(documentObject));
+		this[internalProperties].originalObject = utils.deep_copy(documentObject);
 		this[internalProperties].originalSettings = {...settings};
 
 		Object.defineProperty(this, "model", {
@@ -224,7 +224,7 @@ Document.prepareForObjectFromSchema = async function<T>(object: T, model: Model<
 	if (settings.updateTimestamps) {
 		const schema: Schema = await model.schemaForObject(object);
 		if (schema.settings.timestamps && settings.type === "toDynamo") {
-			const date = new Date();
+			const date = Date.now();
 
 			const createdAtProperties: string[] = ((Array.isArray((schema.settings.timestamps as TimestampObject).createdAt) ? (schema.settings.timestamps as TimestampObject).createdAt : [(schema.settings.timestamps as TimestampObject).createdAt]) as any).filter((a) => Boolean(a));
 			const updatedAtProperties: string[] = ((Array.isArray((schema.settings.timestamps as TimestampObject).updatedAt) ? (schema.settings.timestamps as TimestampObject).updatedAt : [(schema.settings.timestamps as TimestampObject).updatedAt]) as any).filter((a) => Boolean(a));

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -705,7 +705,7 @@ export class Model<T extends DocumentCarrier = AnyDocument> {
 		}
 		if (!updateObj) {
 			const hashKeyName = this.getHashKey();
-			updateObj = keyObj as Partial<T>;
+			updateObj = utils.deep_copy(keyObj) as Partial<T>;
 			keyObj = {
 				[hashKeyName]: keyObj[hashKeyName]
 			};

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -349,7 +349,7 @@ export class Model<T extends DocumentCarrier = AnyDocument> {
 		class Document extends DocumentCarrier {
 			static Model: Model<DocumentCarrier>;
 			constructor (object: DynamoDB.AttributeMap | ObjectType = {}, settings: DocumentSettings = {}) {
-				super(self, object, settings);
+				super(self, utils.deep_copy(object), settings);
 			}
 		}
 		Document.Model = self;

--- a/lib/utils/deep_copy.ts
+++ b/lib/utils/deep_copy.ts
@@ -1,0 +1,33 @@
+export default function deep_copy<T> (obj: T): T {
+	let copy: any;
+
+	// Handle the 3 simple types, and null or undefined
+	if (obj == null || typeof obj !== "object") return obj;
+
+	// Handle Date
+	if (obj instanceof Date) {
+		copy = new Date();
+		copy.setTime(obj.getTime());
+		return copy;
+	}
+
+	// Handle Array
+	if (obj instanceof Array) {
+		copy = [];
+		for (let i = 0, len = obj.length; i < len; i++) {
+			copy[i] = deep_copy(obj[i]);
+		}
+		return copy;
+	}
+
+	// Handle Object
+	if (obj instanceof Object) {
+		copy = {};
+		for (const attr in obj) {
+			if (Object.prototype.hasOwnProperty.call(obj, attr)) copy[attr] = deep_copy(obj[attr]);
+		}
+		return copy;
+	}
+
+	return obj;
+}

--- a/lib/utils/deep_copy.ts
+++ b/lib/utils/deep_copy.ts
@@ -1,5 +1,59 @@
-import * as cloneDeep from "lodash.clonedeep";
-
 export default function deep_copy<T> (obj: T): T {
-	return cloneDeep(obj);
+	let copy: any;
+
+	// Handle Date
+	if (obj instanceof Date) {
+		copy = new Date();
+		copy.setTime(obj.getTime());
+		return copy;
+	}
+
+	// Handle Array
+	if (obj instanceof Array) {
+		copy = obj.map((i) => deep_copy(i));
+		return copy;
+	}
+
+	// Handle Set
+	if (obj instanceof Set) {
+		copy = new Set(obj);
+		return copy;
+	}
+
+	// Handle Map
+	if (obj instanceof Map) {
+		copy = new Map(obj);
+		return copy;
+	}
+
+	// Handle Buffer
+	if (obj instanceof Buffer) {
+		copy = Buffer.from(obj);
+		return copy;
+	}
+
+	// Handle Object
+	if (obj instanceof Object) {
+		if (obj.constructor !== Object) {
+			try {
+				copy = new (obj.constructor as any)();
+			} catch (error) {
+				if (error.code === "InvalidSetType" && error.message === "Sets can contain string, number, or binary values") {
+					copy = new (obj.constructor as any)((obj as any).values);
+				} else {
+					throw error;
+				}
+			}
+		} else {
+			copy = {};
+		}
+		for (const attr in obj) {
+			if (Object.prototype.hasOwnProperty.call(obj, attr)) {
+				copy[attr] = deep_copy(obj[attr]);
+			}
+		}
+		return copy;
+	}
+
+	return obj;
 }

--- a/lib/utils/deep_copy.ts
+++ b/lib/utils/deep_copy.ts
@@ -1,9 +1,6 @@
 export default function deep_copy<T> (obj: T): T {
 	let copy: any;
 
-	// Handle the 3 simple types, and null or undefined
-	if (obj == null || typeof obj !== "object") return obj;
-
 	// Handle Date
 	if (obj instanceof Date) {
 		copy = new Date();
@@ -13,10 +10,7 @@ export default function deep_copy<T> (obj: T): T {
 
 	// Handle Array
 	if (obj instanceof Array) {
-		copy = [];
-		for (let i = 0, len = obj.length; i < len; i++) {
-			copy[i] = deep_copy(obj[i]);
-		}
+		copy = obj.map((i) => deep_copy(i));
 		return copy;
 	}
 

--- a/lib/utils/deep_copy.ts
+++ b/lib/utils/deep_copy.ts
@@ -1,29 +1,5 @@
+import * as cloneDeep from "lodash.clonedeep";
+
 export default function deep_copy<T> (obj: T): T {
-	let copy: any;
-
-	// Handle Date
-	if (obj instanceof Date) {
-		copy = new Date();
-		copy.setTime(obj.getTime());
-		return copy;
-	}
-
-	// Handle Array
-	if (obj instanceof Array) {
-		copy = obj.map((i) => deep_copy(i));
-		return copy;
-	}
-
-	// Handle Object
-	if (obj instanceof Object) {
-		copy = {};
-		for (const attr in obj) {
-			if (Object.prototype.hasOwnProperty.call(obj, attr)) {
-				copy[attr] = deep_copy(obj[attr]);
-			}
-		}
-		return copy;
-	}
-
-	return obj;
+	return cloneDeep(obj);
 }

--- a/lib/utils/deep_copy.ts
+++ b/lib/utils/deep_copy.ts
@@ -35,15 +35,7 @@ export default function deep_copy<T> (obj: T): T {
 	// Handle Object
 	if (obj instanceof Object) {
 		if (obj.constructor !== Object) {
-			try {
-				copy = new (obj.constructor as any)();
-			} catch (error) {
-				if (error.code === "InvalidSetType" && error.message === "Sets can contain string, number, or binary values") {
-					copy = new (obj.constructor as any)((obj as any).values);
-				} else {
-					throw error;
-				}
-			}
+			copy = Object.assign(Object.create(Object.getPrototypeOf(obj)), obj);
 		} else {
 			copy = {};
 		}

--- a/lib/utils/deep_copy.ts
+++ b/lib/utils/deep_copy.ts
@@ -18,7 +18,9 @@ export default function deep_copy<T> (obj: T): T {
 	if (obj instanceof Object) {
 		copy = {};
 		for (const attr in obj) {
-			if (Object.prototype.hasOwnProperty.call(obj, attr)) copy[attr] = deep_copy(obj[attr]);
+			if (Object.prototype.hasOwnProperty.call(obj, attr)) {
+				copy[attr] = deep_copy(obj[attr]);
+			}
 		}
 		return copy;
 	}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -11,6 +11,7 @@ import dynamoose = require("./dynamoose");
 import all_elements_match from "./all_elements_match";
 import type_name from "./type_name";
 import find_best_index from "./find_best_index";
+import deep_copy from "./deep_copy";
 
 export = {
 	combine_objects,
@@ -25,5 +26,6 @@ export = {
 	object,
 	dynamoose,
 	type_name,
-	find_best_index
+	find_best_index,
+	deep_copy
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.7.3",
+      "version": "2.8.1",
       "funding": [
         {
           "type": "github-sponsors",
@@ -20,6 +20,7 @@
       "dependencies": {
         "aws-sdk": "^2.968.0",
         "js-object-utilities": "^2.0.0",
+        "lodash.clonedeep": "^4.5.0",
         "source-map-support": "^0.5.19",
         "uuid": "^8.3.2"
       },
@@ -2624,7 +2625,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
@@ -5968,8 +5968,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
       "dependencies": {
         "aws-sdk": "^2.968.0",
         "js-object-utilities": "^2.0.0",
-        "lodash.clonedeep": "^4.5.0",
         "source-map-support": "^0.5.19",
         "uuid": "^8.3.2"
       },
@@ -2625,6 +2624,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
@@ -5968,7 +5968,8 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "aws-sdk": "^2.968.0",
     "js-object-utilities": "^2.0.0",
-    "lodash.clonedeep": "^4.5.0",
     "source-map-support": "^0.5.19",
     "uuid": "^8.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "aws-sdk": "^2.968.0",
     "js-object-utilities": "^2.0.0",
+    "lodash.clonedeep": "^4.5.0",
     "source-map-support": "^0.5.19",
     "uuid": "^8.3.2"
   },

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -8,6 +8,7 @@ const Internal = require("../../dist/Internal");
 const utils = require("../../dist/utils");
 const util = require("util");
 const ModelStore = require("../../dist/ModelStore");
+const { object } = require("../../dist/utils");
 
 describe("Model", () => {
 	beforeEach(() => {
@@ -3548,6 +3549,15 @@ describe("Model", () => {
 						"id": 1,
 						"address": {"zip": 12345, "country": "world"}
 					});
+				});
+
+				it("Should not delete keys from object", async () => {
+					const obj = {"id": 1, "address": {"zip": 12345, "country": "world"}};
+
+					User = dynamoose.model("User", new dynamoose.Schema({"id": Number, "address": Object}, {"saveUnknown": true}));
+					updateItemFunction = () => Promise.resolve({"Attributes": {"id": {"N": "1"}, "address": {"M": {"zip": {"N": "12345"}, "country": {"S": "world"}}}}});
+					await callType.func(User).bind(User)(obj);
+					expect(obj).to.deep.eql({"id": 1, "address": {"zip": 12345, "country": "world"}});
 				});
 
 				it("Should not throw error if validation passes", () => {

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -8,7 +8,6 @@ const Internal = require("../../dist/Internal");
 const utils = require("../../dist/utils");
 const util = require("util");
 const ModelStore = require("../../dist/ModelStore");
-const { object } = require("../../dist/utils");
 
 describe("Model", () => {
 	beforeEach(() => {

--- a/test/unit/Model.js
+++ b/test/unit/Model.js
@@ -4717,6 +4717,12 @@ describe("Model", () => {
 
 				expect(result).to.eql("Dynamoose Warning: Passing callback function into transaction method not allowed. Removing callback function from list of arguments.");
 			});
+
+			it("Should not delete keys from object", () => {
+				const obj = {"id": 1, "name": "Bob"};
+				User.transaction.update(obj, utils.empty_function);
+				expect(obj).to.eql({"id": 1, "name": "Bob"});
+			});
 		});
 
 		describe("Model.transaction.condition", () => {

--- a/test/unit/utils/deep_copy.js
+++ b/test/unit/utils/deep_copy.js
@@ -117,19 +117,6 @@ describe("utils.deep_copy", () => {
 		expect(copy.name.constructor).to.deep.equal(NameWrapper);
 	});
 
-	it("Should forward errors from class instantiation", () => {
-		class PersonWrapper {
-			constructor (name, age) {
-				this.name = name;
-				this.age = age;
-
-				if (!name || !age) throw new Error("Name and age are required");
-			}
-		}
-		const original = new PersonWrapper("Tim", 20);
-		expect(() => utils.deep_copy(original)).to.throw("Name and age are required");
-	});
-
 	it("Should return a deep copy of the passed set", () => {
 		const original = new Set(["Hello", "World", "Universe"]);
 		const copy = utils.deep_copy(original);

--- a/test/unit/utils/deep_copy.js
+++ b/test/unit/utils/deep_copy.js
@@ -20,22 +20,42 @@ describe("utils.deep_copy", () => {
 	it("Should return a deep copy of the passed class", () => {
 		class Test {
 			constructor () {
-				this.test = "Test";
+				this.foo = "Test";
 			}
 		}
 
 		const original = new Test();
 		const copy = utils.deep_copy(original);
-		expect(copy.test).to.equal("Test");
 
-		original.test = "Test 2";
+		expect(copy.foo).to.equal("Test");
 
-		expect(original.test).to.equal("Test 2");
-		expect(copy.test).to.equal("Test");
+		original.foo = "Test 2";
+
+		expect(original.foo).to.equal("Test 2");
+		expect(copy.foo).to.equal("Test");
+	});
+
+	it("Should not copy prototype", () => {
+		function Test () {
+			this.foo = "Test";
+		}
+
+		Test.prototype = {"bar": "bar_val"};
+
+		const original = new Test();
+		const copy = utils.deep_copy(original);
+
+		expect(copy.foo).to.equal("Test");
+
+		original.foo = "Test 2";
+
+		expect(original.foo).to.equal("Test 2");
+		expect(copy.foo).to.equal("Test");
+		expect(copy.bar).to.be.undefined;
 	});
 
 	it("Should return a deep copy of the passed date", () => {
-		const original = new Date(2021, 2, 1);
+		const original = new Date("Mon, 01 Mar 2021 07:00:00 GMT");
 		const copy = utils.deep_copy(original);
 		expect(copy.toUTCString()).to.equal("Mon, 01 Mar 2021 07:00:00 GMT");
 

--- a/test/unit/utils/deep_copy.js
+++ b/test/unit/utils/deep_copy.js
@@ -6,7 +6,57 @@ describe("utils.deep_copy", () => {
 		expect(utils.deep_copy).to.be.a("function");
 	});
 
-	it("Should return a copy of the object", () => {
+	it("Should return a deep copy of the passed string", () => {
+		let original = "Test";
+		const copy = utils.deep_copy(original);
+		expect(copy).to.equal("Test");
+
+		original = "Test 2";
+
+		expect(original).to.equal("Test 2");
+		expect(copy).to.equal("Test");
+	});
+
+	it("Should return a deep copy of the passed class", () => {
+		class Test {
+			constructor () {
+				this.test = "Test";
+			}
+		}
+
+		const original = new Test();
+		const copy = utils.deep_copy(original);
+		expect(copy.test).to.equal("Test");
+
+		original.test = "Test 2";
+
+		expect(original.test).to.equal("Test 2");
+		expect(copy.test).to.equal("Test");
+	});
+
+	it("Should return a deep copy of the passed date", () => {
+		const original = new Date(2021, 2, 1);
+		const copy = utils.deep_copy(original);
+		expect(copy.toUTCString()).to.equal("Mon, 01 Mar 2021 07:00:00 GMT");
+
+		original.setDate(2);
+
+		expect(original.toUTCString()).to.equal("Tue, 02 Mar 2021 07:00:00 GMT");
+		expect(copy.toUTCString()).to.equal("Mon, 01 Mar 2021 07:00:00 GMT");
+	});
+
+	it("Should return a deep copy of the passed array", () => {
+		const original = [{"a": 1}, {"a": 2}];
+		const copy = utils.deep_copy(original);
+		expect(copy).to.deep.equal([{"a": 1}, {"a": 2}]);
+
+		original[0].a = 2;
+
+		expect(original).to.deep.equal([{"a": 2}, {"a": 2}]);
+		expect(copy).to.deep.equal([{"a": 1}, {"a": 2}]);
+	});
+
+	it("Should return a deep copy of the passed object", () => {
 		const original = {"a": 1, "b": "test", "c": {"d": 100, "e": 200}};
 		const copy = utils.deep_copy(original);
 		expect(copy).to.deep.equal({"a": 1, "b": "test", "c": {"d": 100, "e": 200}});

--- a/test/unit/utils/deep_copy.js
+++ b/test/unit/utils/deep_copy.js
@@ -35,25 +35,6 @@ describe("utils.deep_copy", () => {
 		expect(copy.foo).to.equal("Test");
 	});
 
-	it("Should not copy prototype", () => {
-		function Test () {
-			this.foo = "Test";
-		}
-
-		Test.prototype = {"bar": "bar_val"};
-
-		const original = new Test();
-		const copy = utils.deep_copy(original);
-
-		expect(copy.foo).to.equal("Test");
-
-		original.foo = "Test 2";
-
-		expect(original.foo).to.equal("Test 2");
-		expect(copy.foo).to.equal("Test");
-		expect(copy.bar).to.be.undefined;
-	});
-
 	it("Should return a deep copy of the passed date", () => {
 		const original = new Date("Mon, 01 Mar 2021 07:00:00 GMT");
 		const copy = utils.deep_copy(original);

--- a/test/unit/utils/deep_copy.js
+++ b/test/unit/utils/deep_copy.js
@@ -72,7 +72,7 @@ describe("utils.deep_copy", () => {
 
 	it("Should return a deep copy of the passed class instances", () => {
 		class PersonWrapper {
-			constructor(name, age) {
+			constructor (name, age) {
 				this.name = name;
 				this.age = age;
 			}
@@ -91,13 +91,13 @@ describe("utils.deep_copy", () => {
 
 	it("Should return a deep copy of the passed multiple nested class instances", () => {
 		class NameWrapper {
-			constructor(name) {
+			constructor (name) {
 				this.name = name;
 			}
 		}
 
 		class PersonWrapper {
-			constructor(name, age) {
+			constructor (name, age) {
 				this.name = name;
 				this.age = age;
 			}

--- a/test/unit/utils/deep_copy.js
+++ b/test/unit/utils/deep_copy.js
@@ -1,0 +1,20 @@
+const {expect} = require("chai");
+const utils = require("../../../dist/utils");
+
+describe("utils.deep_copy", () => {
+	it("Should be a function", () => {
+		expect(utils.deep_copy).to.be.a("function");
+	});
+
+	it("Should return a copy of the object", () => {
+		const original = {"a": 1, "b": "test", "c": {"d": 100, "e": 200}};
+		const copy = utils.deep_copy(original);
+		expect(copy).to.deep.equal({"a": 1, "b": "test", "c": {"d": 100, "e": 200}});
+
+		delete original.a;
+		delete original.c.d;
+
+		expect(original).to.deep.equal({"b": "test", "c": {"e": 200}});
+		expect(copy).to.deep.equal({"a": 1, "b": "test", "c": {"d": 100, "e": 200}});
+	});
+});

--- a/test/unit/utils/deep_copy.js
+++ b/test/unit/utils/deep_copy.js
@@ -1,5 +1,6 @@
 const {expect} = require("chai");
 const utils = require("../../../dist/utils");
+const dynamoose = require("../../../dist");
 
 describe("utils.deep_copy", () => {
 	it("Should be a function", () => {
@@ -67,5 +68,99 @@ describe("utils.deep_copy", () => {
 
 		expect(original).to.deep.equal({"b": "test", "c": {"e": 200}});
 		expect(copy).to.deep.equal({"a": 1, "b": "test", "c": {"d": 100, "e": 200}});
+	});
+
+	it("Should return a deep copy of the passed class instances", () => {
+		class PersonWrapper {
+			constructor(name, age) {
+				this.name = name;
+				this.age = age;
+			}
+		}
+		const original = new PersonWrapper("Tim", 20);
+		const copy = utils.deep_copy(original);
+		expect(copy).to.deep.equal(new PersonWrapper("Tim", 20));
+
+		original.name = undefined;
+
+		expect(original).to.deep.equal(new PersonWrapper(undefined, 20));
+		expect(copy).to.deep.equal(new PersonWrapper("Tim", 20));
+		expect(original.constructor).to.deep.equal(PersonWrapper);
+		expect(copy.constructor).to.deep.equal(PersonWrapper);
+	});
+
+	it("Should return a deep copy of the passed multiple nested class instances", () => {
+		class NameWrapper {
+			constructor(name) {
+				this.name = name;
+			}
+		}
+
+		class PersonWrapper {
+			constructor(name, age) {
+				this.name = name;
+				this.age = age;
+			}
+		}
+		const original = new PersonWrapper(new NameWrapper("Tim"), 20);
+		const copy = utils.deep_copy(original);
+		expect(copy).to.deep.equal(new PersonWrapper(new NameWrapper("Tim"), 20));
+
+		original.name.name = undefined;
+		original.age = 25;
+
+		expect(original).to.deep.equal(new PersonWrapper(new NameWrapper(undefined), 25));
+		expect(copy).to.deep.equal(new PersonWrapper(new NameWrapper("Tim"), 20));
+		expect(original.constructor).to.deep.equal(PersonWrapper);
+		expect(copy.constructor).to.deep.equal(PersonWrapper);
+		expect(original.name.constructor).to.deep.equal(NameWrapper);
+		expect(copy.name.constructor).to.deep.equal(NameWrapper);
+	});
+
+	it("Should return a deep copy of the passed set", () => {
+		const original = new Set(["Hello", "World", "Universe"]);
+		const copy = utils.deep_copy(original);
+		expect([...copy]).to.deep.equal(["Hello", "World", "Universe"]);
+
+		original.delete("Hello");
+
+		expect([...original]).to.deep.equal(["World", "Universe"]);
+		expect([...copy]).to.deep.equal(["Hello", "World", "Universe"]);
+	});
+
+	it("Should return a deep copy of the passed DynamoDB set", () => {
+		const original = dynamoose.aws.converter().output({"SS": ["Hello", "World", "Universe"]});
+		const copy = utils.deep_copy(original);
+		expect(copy).to.deep.equal(dynamoose.aws.converter().output({"SS": ["Hello", "World", "Universe"]}));
+
+		original.values[0] = "Welcome";
+
+		expect(original).to.deep.equal(dynamoose.aws.converter().output({"SS": ["Welcome", "World", "Universe"]}));
+		expect(copy).to.deep.equal(dynamoose.aws.converter().output({"SS": ["Hello", "World", "Universe"]}));
+		expect(copy.constructor).to.deep.equal(original.constructor);
+	});
+
+	it("Should return a deep copy of the passed map", () => {
+		const original = new Map();
+		original.set("a", 1);
+		original.set("b", 2);
+		const copy = utils.deep_copy(original);
+		expect(Object.fromEntries(copy)).to.deep.equal({"a": 1, "b": 2});
+
+		original.delete("b");
+
+		expect(Object.fromEntries(original)).to.deep.equal({"a": 1});
+		expect(Object.fromEntries(copy)).to.deep.equal({"a": 1, "b": 2});
+	});
+
+	it("Should return a deep copy of the passed buffer", () => {
+		let original = Buffer.from("Hello World!");
+		const copy = utils.deep_copy(original);
+		expect(copy.toString()).to.deep.equal("Hello World!");
+
+		original[0] = 0;
+
+		expect(original.toString()).to.deep.equal("\u0000ello World!");
+		expect(copy.toString()).to.deep.equal("Hello World!");
 	});
 });


### PR DESCRIPTION
### Summary:

See summaries below per-issue.

#### Closes #1257

Previously, updating a document would cause the hash and range keys on the passed object to be deleted. This PR uses `deep_copy` to copy the passed object and ensure the original does not get mutated.

```ts
it("Should not delete keys from object", async () => {
	const obj = {"id": 1, "address": {"zip": 12345, "country": "world"}};

	User = dynamoose.model("User", new dynamoose.Schema({"id": Number, "address": Object}, {"saveUnknown": true}));
	updateItemFunction = () => Promise.resolve({"Attributes": {"id": {"N": "1"}, "address": {"M": {"zip": {"N": "12345"}, "country": {"S": "world"}}}}});
	await callType.func(User).bind(User)(obj);
	expect(obj).to.deep.eql({"id": 1, "address": {"zip": 12345, "country": "world"}});
});
```

#### Closes #1163 

Previously, re-saving a Document would cause the `updatedAt` property to be a `Date` (rather than a numeric epoch time like the others). This PR ensures the type of `updatedAt` and `createdAt` properties are consistently numeric, rather than Date objects.

```ts
it("Should return correct result after saving with timestamps", async () => {
	createItemFunction = () => Promise.resolve();
	User = dynamoose.model("User", new dynamoose.Schema({"id": Number, "name": String}, {"timestamps": true}));
	const date1 = Date.now();
	const obj = {"id": 1, "name": "Charlie"};
	const result = await callType.func(User).bind(User)(obj);

	// Check original timestamps
	expect(result.id).to.eql(1);
	expect(result.name).to.eql("Charlie");
	expect(result.createdAt).to.be.a("number");
	expect(result.createdAt).to.be.within(date1 - 10, date1 + 10);
	expect(result.updatedAt).to.be.a("number");
	expect(result.updatedAt).to.be.within(date1 - 10, date1 + 10);

	await new Promise((resolve) => setTimeout(resolve, 20));

	const date2 = Date.now();

	// Mutate document and re-save
	result.name = "Charlie 2";
	const result2 = await result.save();

	expect(result.toJSON()).to.eql(result2.toJSON());
	[result, result2].forEach((r) => {
		expect(r.id).to.eql(1);
		expect(r.name).to.eql("Charlie 2");
		expect(r.createdAt).to.be.a("number");
		expect(r.createdAt).to.be.within(date1 - 10, date1 + 10);
		expect(r.updatedAt).to.be.a("number");
		expect(r.updatedAt).to.be.within(date2 - 10, date2 + 10);
	});
});
```

#### Closes #1059

Previously, creating a document from an object with deep/nested non-schema properties would mutate the passed object. This PR updates this behavior to leave the passed object untouched, and only mutate the returned document.

```ts
it("Should not mutate original object if properties not in schema", async () => {
	createItemFunction = () => Promise.resolve();
	const obj = {"id": 1, "random": "data"};
	await callType.func(User).bind(User)(obj);
	expect(obj).to.be.an("object");
	expect(obj).to.deep.eql({
		"id": 1,
		"random": "data"
	});
});

it("Should not mutate original object if nested object properties not in schema", async () => {
	createItemFunction = () => Promise.resolve();
	const obj = {"id": 1, "randomdata": {"hello": "world"}};
	await callType.func(User).bind(User)(obj);
	expect(obj).to.be.an("object");
	expect(obj).to.deep.eql({
		"id": 1,
		"randomdata": {
			"hello": "world"
		}
	});
});
```

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Something not listed here

### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure

### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No

### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No

### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
