### PR TITLE
Fix date test instability

### DIFF
--- a/test/unit/utils/deep_copy.js
+++ b/test/unit/utils/deep_copy.js
@@ -41,7 +41,7 @@ describe("utils.deep_copy", () => {
 		const copy = utils.deep_copy(original);
 		expect(copy.toUTCString()).to.equal("Mon, 01 Mar 2021 07:00:00 GMT");
 
-		original.setDate(2);
+		original.setUTCDate(2);
 
 		expect(original.toUTCString()).to.equal("Tue, 02 Mar 2021 07:00:00 GMT");
 		expect(copy.toUTCString()).to.equal("Mon, 01 Mar 2021 07:00:00 GMT");


### PR DESCRIPTION
### Summary:

If the test-runner is in a timezone earlier than GMT-7, the
"Should return a deep copy of the passed date" `deep_copy`
test would fail. This changes the test to use setUTCDate
instead, which is non-timezone dependent.

### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [x] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above