### PR TITLE
Add types for Model updates using $SET and other fields

### DIFF
--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -48,6 +48,15 @@ export interface ModelOptions {
 }
 export type ModelOptionsOptional = DeepPartial<ModelOptions>;
 
+export type ModelUpdateSpecialFields<T> = {
+	$SET?: Partial<T>
+	$ADD?: Record<keyof T, any>
+	$REMOVE?: Array<keyof T> | Record<keyof T, null>
+	$DELETE?: Record<keyof T, any>
+};
+
+export type ModelUpdateObject<T> = Partial<T> & ModelUpdateSpecialFields<T>;
+
 
 type KeyObject = {[attribute: string]: string | number};
 type InputKey = string | number | KeyObject;
@@ -678,25 +687,25 @@ export class Model<T extends DocumentCarrier = AnyDocument> {
 	}
 
 	// Update
-	update (obj: Partial<T>): Promise<T>;
-	update (obj: Partial<T>, callback: CallbackType<T, AWSError>): void;
-	update (keyObj: InputKey, updateObj: Partial<T>): Promise<T>;
-	update (keyObj: InputKey, updateObj: Partial<T>, callback: CallbackType<T, AWSError>): void;
-	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "request"}): Promise<DynamoDB.UpdateItemInput>;
-	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "request"}, callback: CallbackType<DynamoDB.UpdateItemInput, AWSError>): void;
-	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings): Promise<T>;
-	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings, callback: CallbackType<T, AWSError>): void;
-	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "document"}): Promise<T>;
-	update (keyObj: InputKey, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "document"}, callback: CallbackType<T, AWSError>): void;
-	update (keyObj: ObjectType, updateObj: Partial<T>): Promise<T>;
-	update (keyObj: ObjectType, updateObj: Partial<T>, callback: CallbackType<T, AWSError>): void;
-	update (keyObj: ObjectType, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "request"}): Promise<DynamoDB.UpdateItemInput>;
-	update (keyObj: ObjectType, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "request"}, callback: CallbackType<DynamoDB.UpdateItemInput, AWSError>): void;
-	update (keyObj: ObjectType, updateObj: Partial<T>, settings: ModelUpdateSettings): Promise<T>;
-	update (keyObj: ObjectType, updateObj: Partial<T>, settings: ModelUpdateSettings, callback: CallbackType<T, AWSError>): void;
-	update (keyObj: ObjectType, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "document"}): Promise<T>;
-	update (keyObj: ObjectType, updateObj: Partial<T>, settings: ModelUpdateSettings & {"return": "document"}, callback: CallbackType<T, AWSError>): void;
-	update (keyObj: InputKey | ObjectType, updateObj?: Partial<T> | CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>, settings?: ModelUpdateSettings | CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>, callback?: CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>): void | Promise<T> | Promise<DynamoDB.UpdateItemInput> {
+	update (obj: ModelUpdateObject<T>): Promise<T>;
+	update (obj: ModelUpdateObject<T>, callback: CallbackType<T, AWSError>): void;
+	update (keyObj: InputKey, updateObj: ModelUpdateObject<T>): Promise<T>;
+	update (keyObj: InputKey, updateObj: ModelUpdateObject<T>, callback: CallbackType<T, AWSError>): void;
+	update (keyObj: InputKey, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings & {"return": "request"}): Promise<DynamoDB.UpdateItemInput>;
+	update (keyObj: InputKey, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings & {"return": "request"}, callback: CallbackType<DynamoDB.UpdateItemInput, AWSError>): void;
+	update (keyObj: InputKey, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings): Promise<T>;
+	update (keyObj: InputKey, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings, callback: CallbackType<T, AWSError>): void;
+	update (keyObj: InputKey, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings & {"return": "document"}): Promise<T>;
+	update (keyObj: InputKey, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings & {"return": "document"}, callback: CallbackType<T, AWSError>): void;
+	update (keyObj: ObjectType, updateObj: ModelUpdateObject<T>): Promise<T>;
+	update (keyObj: ObjectType, updateObj: ModelUpdateObject<T>, callback: CallbackType<T, AWSError>): void;
+	update (keyObj: ObjectType, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings & {"return": "request"}): Promise<DynamoDB.UpdateItemInput>;
+	update (keyObj: ObjectType, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings & {"return": "request"}, callback: CallbackType<DynamoDB.UpdateItemInput, AWSError>): void;
+	update (keyObj: ObjectType, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings): Promise<T>;
+	update (keyObj: ObjectType, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings, callback: CallbackType<T, AWSError>): void;
+	update (keyObj: ObjectType, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings & {"return": "document"}): Promise<T>;
+	update (keyObj: ObjectType, updateObj: ModelUpdateObject<T>, settings: ModelUpdateSettings & {"return": "document"}, callback: CallbackType<T, AWSError>): void;
+	update (keyObj: InputKey | ObjectType, updateObj?: ModelUpdateObject<T> | CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>, settings?: ModelUpdateSettings | CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>, callback?: CallbackType<T, AWSError> | CallbackType<DynamoDB.UpdateItemInput, AWSError>): void | Promise<T> | Promise<DynamoDB.UpdateItemInput> {
 		if (typeof updateObj === "function") {
 			callback = updateObj as CallbackType<DocumentCarrier | DynamoDB.UpdateItemInput, AWSError>; // TODO: fix this, for some reason `updateObj` has a type of Function which is forcing us to type cast it
 			updateObj = null;
@@ -708,7 +717,7 @@ export class Model<T extends DocumentCarrier = AnyDocument> {
 		}
 		if (!updateObj) {
 			const hashKeyName = this.getHashKey();
-			updateObj = utils.deep_copy(keyObj) as Partial<T>;
+			updateObj = utils.deep_copy(keyObj) as ModelUpdateObject<T>;
 			keyObj = {
 				[hashKeyName]: keyObj[hashKeyName]
 			};

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -50,9 +50,9 @@ export type ModelOptionsOptional = DeepPartial<ModelOptions>;
 
 export type ModelUpdateSpecialFields<T> = {
 	$SET?: Partial<T>
-	$ADD?: Record<keyof T, any>
-	$REMOVE?: Array<keyof T> | Record<keyof T, null>
-	$DELETE?: Record<keyof T, any>
+	$ADD?: Partial<Record<keyof T, any>>
+	$REMOVE?: Array<keyof T> | Partial<Record<keyof T, null>>
+	$DELETE?: Partial<Record<keyof T, any>>
 };
 
 export type ModelUpdateObject<T> = Partial<T> & ModelUpdateSpecialFields<T>;


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:

`Model.update()` is typed to allow only fields from the model. Extra fields like: `$SET` or `$DELETE` are shown as errors when using typescript. I've added them as optional fields.

Please feel free to improve on the typing, I've tried to get it as close as I could.


<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
```javascript
await Model.update(
  { id: 1 },
  {
    $SET: { foo: "bar" },
    $ADD: { version: 1 },
  },
)
```



### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [ ] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [ ] I have ensured the following commands are successful from the root of the project directory
  - [ ] `npm test`
  - [ ] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/master/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [ ] I have filled out all fields above
