### PR TITLE
Don't register source-map-support if other pkg has

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import "source-map-support/register";
+import * as sourceMapSupport from "source-map-support";
 
 import {Model, ModelOptionsOptional} from "./Model";
 import {Schema, SchemaDefinition} from "./Schema";
@@ -11,6 +11,12 @@ import logger = require("./logger");
 import {Document, AnyDocument} from "./Document";
 import ModelStore = require("./ModelStore");
 import {ModelType} from "./General";
+
+/* istanbul ignore next */
+if (!Error.prepareStackTrace) {
+	// Register source map support only if someone else hasn't already:
+	sourceMapSupport.install();
+}
 
 const model = <T extends Document = AnyDocument>(name: string, schema?: Schema | SchemaDefinition | (Schema | SchemaDefinition)[], options: ModelOptionsOptional = {}): ModelType<T> => {
 	let model: Model<T>;


### PR DESCRIPTION
See comments by martin-oa in issue [#1019](https://github.com/dynamoose/dynamoose/issues/1019#issuecomment-977989650)

### Summary:

The source-map-support package overwrites the global `Error.prepareStackTrace` function. If it is imported twice by different packages, they can sometimes both overwrite it, causing conflicts. In particular, when running our jest tests it prevents jest from giving correct line numbers.

See also this comment of mine:

https://github.com/dynamoose/dynamoose/issues/1019#issuecomment-977989650

Unfortunately it's not easily possible to get test coverage on this change, so I had to disable coverage on it to keep 100% test coverage.

### Type (select 1):
- [X] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [X] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [X] Yes
- [ ] No


### Other:
- [X] I have read through and followed the Contributing Guidelines
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [-] I have updated the Dynamoose documentation (if required) given the changes I made
- [-] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [X] I have ensured the following commands are successful from the root of the project directory
  - [X] `npm test`
  - [X] `npm run lint`
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have filled out all fields above
