### PR TITLE
Version 2.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ---
 
+## Version 2.8.3
+
+This release fixes a bug if you started `source-map-support` yourself where Dynamoose would try to do the same and would lead to conflicts.
+
+Please comment or [contact me](https://charlie.fish/contact) if you have any questions about this release.
+
+### Bug Fixes
+
+- Not registering `source-map-support` if already initialized.
+
+### Other
+
+- Renamed primary branch from `master` to `main`.
+- Added Node.js v16.x to CI test suite.
+- General v3 alpha README fixes.
+
+---
+
 ## Version 2.8.2
 
 This release fixes a few major bugs.

--- a/README.md
+++ b/README.md
@@ -71,4 +71,5 @@ Below you will find the current branch strategy for the project. Work taking pla
 | --- | --- | --- | --- |
 | [`v3`](https://github.com/dynamoose/dynamoose/tree/v3) | 3.0.0 | alpha | - [Documentation](https://v3.dynamoose.pages.dev/)<br>- [Pending Changelog](https://github.com/dynamoose/dynamoose/blob/v3/PENDING_CHANGELOG.md) |
 | [`main`](https://github.com/dynamoose/dynamoose/tree/main) | 2.8.x |   | - [Documentation](https://dynamoose.pages.dev/) |
-| [`v2.8.2` (tag)](https://github.com/dynamoose/dynamoose/tree/v2.8.2) | 2.8.2 | latest | - [Documentation](https://dynamoosejs.com)
+| [`v2.8.3` (tag)](https://github.com/dynamoose/dynamoose/tree/v2.8.3) | 2.8.3 | latest | - [Documentation](https://dynamoosejs.com)
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "dynamoose",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.8.2",
+      "version": "2.8.3",
       "funding": [
         {
           "type": "github-sponsors",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Dynamoose is a modeling tool for Amazon's DynamoDB (inspired by Mongoose)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Version 2.8.3

This release fixes a bug if you started `source-map-support` yourself where Dynamoose would try to do the same and would lead to conflicts.

Please comment or [contact me](https://charlie.fish/contact) if you have any questions about this release.

### Bug Fixes

- Not registering `source-map-support` if already initialized.

### Other

- Renamed primary branch from `master` to `main`.
- Added Node.js v16.x to CI test suite.
- General v3 alpha README fixes.