### PR TITLE
Add model name to transactions

### DIFF
--- a/__tests__/Model.js
+++ b/__tests__/Model.js
@@ -4004,7 +4004,8 @@ describe("Model", () => {
 				expect(await User.transaction.get(1)).toEqual({
 					"Get": {
 						"Key": {"id": {"N": "1"}},
-						"TableName": "User"
+						"TableName": "User",
+						"ModelName":"User"
 					}
 				});
 			});
@@ -4037,7 +4038,8 @@ describe("Model", () => {
 							"#__hash_key": "id"
 						},
 						"Item": {"id": {"N": "1"}},
-						"TableName": "User"
+						"TableName": "User",
+						"ModelName":"User"
 					}
 				});
 			});
@@ -4046,7 +4048,8 @@ describe("Model", () => {
 				expect(await User.transaction.create({"id": 1}, {"overwrite": true})).toEqual({
 					"Put": {
 						"Item": {"id": {"N": "1"}},
-						"TableName": "User"
+						"TableName": "User",
+						"ModelName":"User"
 					}
 				});
 			});
@@ -4059,7 +4062,8 @@ describe("Model", () => {
 							"#__hash_key": "id"
 						},
 						"Item": {"id": {"N": "1"}},
-						"TableName": "User"
+						"TableName": "User",
+						"ModelName":"User"
 					}
 				});
 			});
@@ -4088,7 +4092,8 @@ describe("Model", () => {
 				expect(await User.transaction.delete(1)).toEqual({
 					"Delete": {
 						"Key": {"id": {"N": "1"}},
-						"TableName": "User"
+						"TableName": "User",
+						"ModelName":"User"
 					}
 				});
 			});
@@ -4109,7 +4114,8 @@ describe("Model", () => {
 				expect(await User.transaction.delete({"id": "foo", "order": 0})).toEqual({
 					"Delete": {
 						"Key": {"id": {"S": "foo"}, "order": {"N": "0"}},
-						"TableName": "User"
+						"TableName": "User",
+						"ModelName":"User"
 					}
 				});
 			});
@@ -4135,7 +4141,8 @@ describe("Model", () => {
 							":v0": {"S": "Bob"}
 						},
 						"UpdateExpression": "SET #a0 = :v0",
-						"TableName": "User"
+						"TableName": "User",
+						"ModelName":"User"
 					}
 				});
 			});
@@ -4151,7 +4158,8 @@ describe("Model", () => {
 							":v0": {"S": "Bob"}
 						},
 						"UpdateExpression": "SET #a0 = :v0",
-						"TableName": "User"
+						"TableName": "User",
+						"ModelName":"User"
 					}
 				});
 			});
@@ -4186,7 +4194,8 @@ describe("Model", () => {
 				expect(await User.transaction.condition(1)).toEqual({
 					"ConditionCheck": {
 						"Key": {"id": {"N": "1"}},
-						"TableName": "User"
+						"TableName": "User",
+						"ModelName": "User"
 					}
 				});
 			});
@@ -4197,7 +4206,8 @@ describe("Model", () => {
 				expect(await User.transaction.condition({"id": 1, "name": "Bob"})).toEqual({
 					"ConditionCheck": {
 						"Key": {"id": {"N": "1"}, "name": {"S": "Bob"}},
-						"TableName": "User"
+						"TableName": "User",
+						"ModelName": "User"
 					}
 				});
 			});
@@ -4213,7 +4223,8 @@ describe("Model", () => {
 							":v0": {"N": "13"}
 						},
 						"Key": {"id": {"N": "1"}},
-						"TableName": "User"
+						"TableName": "User",
+						"ModelName": "User"
 					}
 				});
 			});

--- a/__tests__/Transaction.js
+++ b/__tests__/Transaction.js
@@ -35,14 +35,15 @@ describe("Transaction", () => {
 			});
 
 			it("Should return request if return setting is set to request", () => {
-				return expect(callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "User"}}], {"return": "request"})).resolves.toEqual({
+				return expect(callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "Table", "ModelName": "User"}}], {"return": "request"})).resolves.toEqual({
 					"TransactItems": [
 						{
 							"Get": {
 								"Key": {
 									"id": {"N": "1"}
 								},
-								"TableName": "User"
+								"TableName": "Table",
+								"ModelName":"User"
 							}
 						}
 					]
@@ -50,12 +51,12 @@ describe("Transaction", () => {
 			});
 
 			it("Should throw error if invalid custom type passed in", () => {
-				return expect(callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "User"}}], {"type": "random"})).rejects.toEqual(new CustomError.InvalidParameter("Invalid type option, please pass in \"get\" or \"write\"."));
+				return expect(callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "Table", "ModelName": "User"}}], {"type": "random"})).rejects.toEqual(new CustomError.InvalidParameter("Invalid type option, please pass in \"get\" or \"write\"."));
 			});
 
 			it("Should throw error if model hasn't been created", () => {
 				dynamoose.model("User", {"id": Number, "name": String});
-				return expect(callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "User"}}, {"Get": {"Key": {"id": {"N": "2"}}, "TableName": "Credit"}}])).rejects.toEqual(new CustomError.InvalidParameter("Model \"Credit\" not found. Please register the model with dynamoose before using it in transactions."));
+				return expect(callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "Table", "ModelName": "User"}}, {"Get": {"Key": {"id": {"N": "2"}}, "TableName": "Table", "ModelName": "Credit"}}])).rejects.toEqual(new CustomError.InvalidParameter("Model \"Credit\" not found. Please register the model with dynamoose before using it in transactions."));
 			});
 
 			it("Should send correct parameters to AWS", async () => {
@@ -70,7 +71,7 @@ describe("Transaction", () => {
 				const User = dynamoose.model("User", {"id": Number, "name": String});
 				const Credit = dynamoose.model("Credit", {"id": Number, "name": String});
 				new dynamoose.Table("Table", [User, Credit]);
-				await callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "User"}}, {"Get": {"Key": {"id": {"N": "2"}}, "TableName": "Credit"}}]);
+				await callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "Table", "ModelName": "User"}}, {"Get": {"Key": {"id": {"N": "2"}}, "TableName": "Table", "ModelName": "Credit"}}]);
 				expect(transactParams).toEqual({
 					"TransactItems": [
 						{
@@ -78,7 +79,8 @@ describe("Transaction", () => {
 								"Key": {
 									"id": {"N": "1"}
 								},
-								"TableName": "User"
+								"TableName": "Table",
+								"ModelName": "User"
 							}
 						},
 						{
@@ -86,7 +88,8 @@ describe("Transaction", () => {
 								"Key": {
 									"id": {"N": "2"}
 								},
-								"TableName": "Credit"
+								"TableName": "Table",
+								"ModelName": "Credit"
 							}
 						}
 					]
@@ -105,7 +108,7 @@ describe("Transaction", () => {
 				const User = dynamoose.model("User", {"id": Number, "name": String});
 				const Credit = dynamoose.model("Credit", {"id": Number, "name": String});
 				new dynamoose.Table("Table", [User, Credit]);
-				await callType.func(dynamoose.transaction)([{"Put": {"Key": {"id": {"N": "1"}}, "TableName": "User"}}, {"Put": {"Key": {"id": {"N": "2"}}, "TableName": "Credit"}}]);
+				await callType.func(dynamoose.transaction)([{"Put": {"Key": {"id": {"N": "1"}}, "TableName": "Table", "ModelName": "User"}}, {"Put": {"Key": {"id": {"N": "2"}}, "TableName": "Table", "ModelName": "Credit"}}]);
 				expect(transactParams).toEqual({
 					"TransactItems": [
 						{
@@ -113,7 +116,8 @@ describe("Transaction", () => {
 								"Key": {
 									"id": {"N": "1"}
 								},
-								"TableName": "User"
+								"TableName": "Table",
+								"ModelName":"User"
 							}
 						},
 						{
@@ -121,7 +125,8 @@ describe("Transaction", () => {
 								"Key": {
 									"id": {"N": "2"}
 								},
-								"TableName": "Credit"
+								"TableName": "Table",
+								"ModelName":"Credit"
 							}
 						}
 					]
@@ -136,7 +141,7 @@ describe("Transaction", () => {
 				const User = dynamoose.model("User", {"id": Number, "name": String});
 				const Credit = dynamoose.model("Credit", {"id": Number, "name": String});
 				new dynamoose.Table("Table", [User, Credit]);
-				return expect(callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "User"}}, {"Get": {"Key": {"id": {"N": "2"}}, "TableName": "Credit"}}]).then((res) => res.map((a) => ({...a})))).resolves.toEqual([
+				return expect(callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "Table", "ModelName": "User"}}, {"Get": {"Key": {"id": {"N": "2"}}, "TableName": "Table", "ModelName": "Credit"}}]).then((res) => res.map((a) => ({...a})))).resolves.toEqual([
 					{"id": 1, "name": "Bob"},
 					{"id": 2, "name": "My Credit"}
 				]);
@@ -150,7 +155,7 @@ describe("Transaction", () => {
 				const User = dynamoose.model("User", {"id": Number, "name": String});
 				const Credit = dynamoose.model("Credit", {"id": Number, "name": String});
 				new dynamoose.Table("Table", [User, Credit]);
-				return expect(callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "User"}}, {"Get": {"Key": {"id": {"N": "2"}}, "TableName": "Credit"}}])).resolves.toEqual(null);
+				return expect(callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "Table", "ModelName": "User"}}, {"Get": {"Key": {"id": {"N": "2"}}, "TableName": "Table", "ModelName": "Credit"}}])).resolves.toEqual(null);
 			});
 
 			it("Should send correct parameters to AWS for custom type of write", async () => {
@@ -165,7 +170,7 @@ describe("Transaction", () => {
 				const User = dynamoose.model("User", {"id": Number, "name": String});
 				const Credit = dynamoose.model("Credit", {"id": Number, "name": String});
 				new dynamoose.Table("Table", [User, Credit]);
-				await callType.func(dynamoose.transaction)([{"Put": {"Key": {"id": {"N": "1"}}, "TableName": "User"}}, {"Put": {"Key": {"id": {"N": "2"}}, "TableName": "Credit"}}], {"type": "write"});
+				await callType.func(dynamoose.transaction)([{"Put": {"Key": {"id": {"N": "1"}}, "TableName": "Table", "ModelName": "User"}}, {"Put": {"Key": {"id": {"N": "2"}}, "TableName": "Table", "ModelName": "Credit"}}], {"type": "write"});
 				expect(transactParams).toBeInstanceOf(Object);
 			});
 
@@ -181,7 +186,7 @@ describe("Transaction", () => {
 				const User = dynamoose.model("User", {"id": Number, "name": String});
 				const Credit = dynamoose.model("Credit", {"id": Number, "name": String});
 				new dynamoose.Table("Table", [User, Credit]);
-				await callType.func(dynamoose.transaction)([{"Put": {"Key": {"id": {"N": "1"}}, "TableName": "User"}}, {"Put": {"Key": {"id": {"N": "2"}}, "TableName": "Credit"}}], {"type": "get"});
+				await callType.func(dynamoose.transaction)([{"Put": {"Key": {"id": {"N": "1"}}, "TableName": "Table", "ModelName": "User"}}, {"Put": {"Key": {"id": {"N": "2"}}, "TableName": "Table", "ModelName": "Credit"}}], {"type": "get"});
 				expect(transactParams).toBeInstanceOf(Object);
 			});
 		});

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -61,6 +61,13 @@ type TransactionType = {
 	condition: ConditionTransaction;
 };
 
+interface ExtendedTransactWriteItem extends DynamoDB.TransactWriteItem {
+	ConditionCheck?: DynamoDB.ConditionCheck & {"ModelName": string};
+	Put?: DynamoDB.Put & {"ModelName": string};
+	Delete?: DynamoDB.Delete & {"ModelName": string};
+	Update?: DynamoDB.Update & {"ModelName": string};
+}
+
 interface ModelGetSettings {
 	return?: "item" | "request";
 	attributes?: string[];
@@ -244,7 +251,7 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 			const settingsIndex = currentValue.settingsIndex || 1;
 			const func = currentValue.function || this[key].bind(this);
 
-			accumulator[key] = async (...args): Promise<DynamoDB.TransactWriteItem> => {
+			accumulator[key] = async (...args): Promise<ExtendedTransactWriteItem> => {
 				if (typeof args[args.length - 1] === "function") {
 					console.warn("Dynamoose Warning: Passing callback function into transaction method not allowed. Removing callback function from list of arguments."); // eslint-disable-line no-console
 					args.pop();

--- a/lib/Model/index.ts
+++ b/lib/Model/index.ts
@@ -257,7 +257,7 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 				if (modifier) {
 					result = modifier(result);
 				}
-				return {[dynamoKey]: result};
+				return {[dynamoKey]: {...result, "ModelName": this.name}};
 			};
 
 			return accumulator;

--- a/lib/Transaction.ts
+++ b/lib/Transaction.ts
@@ -87,7 +87,7 @@ function Transaction (transactions: Transactions, settings?: TransactionSettings
 			transactionType = transactionObjects.map((a) => Object.keys(a)[0]).every((key) => key === "Get") ? "transactGetItems" : "transactWriteItems";
 		}
 
-		const modelNames: string[] = transactionObjects.map((a) => (Object.values(a)[0] as any).TableName);
+		const modelNames: string[] = transactionObjects.map((a) => (Object.values(a)[0] as any).ModelName);
 		const uniqueModelNames = utils.unique_array_elements(modelNames);
 		const models: Model<Item>[] = uniqueModelNames.map((name) => ModelStore(name));
 		models.forEach((model, index) => {


### PR DESCRIPTION
### Summary:
This PR solves an issue when trying to run a transaction and the table name is different from the model (or if the table has prefix/suffix)
No need to write additional tests, I've just updated the current ones by adding the table name on the transaction itself.

Not sure if it's the best approach but I would be happy to enhance it if necessary

### Type (select 1):
- [X] Bug fix


### Is this a breaking change? (select 1):
- [X] No


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes

### Other:
- [X] I have read through and followed the Contributing Guidelines
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [X] I have updated the Dynamoose documentation (if required) given the changes I made
- [X] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [X] I have ensured the following commands are successful from the root of the project directory
  - [X] `npm test`
  - [X] `npm run lint`
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have filled out all fields above
