### PR TITLE
Fix validate and set schema types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,8 @@ module.exports = {
 				"space-before-function-paren": "off",
 				"@typescript-eslint/space-before-function-paren": "error",
 				"@typescript-eslint/ban-types": "off",
-				"@typescript-eslint/explicit-module-boundary-types": "off"
+				"@typescript-eslint/explicit-module-boundary-types": "off",
+				"@typescript-eslint/space-infix-ops": "error"
 			}
 		}
 	],

--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -271,7 +271,7 @@ interface AttributeDefinition {
 	schema?: AttributeType | AttributeType[] | AttributeDefinition | AttributeDefinition[] | SchemaDefinition | SchemaDefinition[];
 	default?: ValueType | (() => ValueType);
 	forceDefault?: boolean;
-	validate?: ValueType | RegExp | ((value: ValueType) => boolean);
+	validate?: ValueType | RegExp | ((value: ValueType) => boolean|Promise<boolean>);
 	required?: boolean;
 	enum?: ValueType[];
 	get?: ((value: ValueType) => ValueType);

--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -275,7 +275,7 @@ interface AttributeDefinition {
 	required?: boolean;
 	enum?: ValueType[];
 	get?: ((value: ValueType) => ValueType);
-	set?: ((value: ValueType) => ValueType);
+	set?: ((value: ValueType, oldValue?: ValueType) => ValueType | Promise<ValueType>);
 	index?: boolean | IndexDefinition | IndexDefinition[];
 	hashKey?: boolean;
 	rangeKey?: boolean;

--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -271,7 +271,7 @@ interface AttributeDefinition {
 	schema?: AttributeType | AttributeType[] | AttributeDefinition | AttributeDefinition[] | SchemaDefinition | SchemaDefinition[];
 	default?: ValueType | (() => ValueType);
 	forceDefault?: boolean;
-	validate?: ValueType | RegExp | ((value: ValueType) => boolean|Promise<boolean>);
+	validate?: ValueType | RegExp | ((value: ValueType) => boolean | Promise<boolean>);
 	required?: boolean;
 	enum?: ValueType[];
 	get?: ((value: ValueType) => ValueType);

--- a/test/types/Schema.ts
+++ b/test/types/Schema.ts
@@ -97,3 +97,15 @@ const shouldSucceedWithArrayOfTypesInNestedSchema = new dynamoose.Schema({
 		]
 	}
 });
+const shouldSucceedWithAsyncSetMethodSchema = new dynamoose.Schema({
+	"id": {
+		"type": String,
+		"set": (value) => Promise.resolve(value)
+	}
+});
+const shouldSucceedWithSetMethodSecondArgSchema = new dynamoose.Schema({
+	"id": {
+		"type": String,
+		"set": (value, oldValue) => oldValue
+	}
+});

--- a/test/types/Schema.ts
+++ b/test/types/Schema.ts
@@ -109,3 +109,9 @@ const shouldSucceedWithSetMethodSecondArgSchema = new dynamoose.Schema({
 		"set": (value, oldValue) => oldValue
 	}
 });
+const shouldSucceedWithAsyncValidateMethodSchema = new dynamoose.Schema({
+	"id": {
+		"type": String,
+		"validate": (value) => Promise.resolve(true)
+	}
+});


### PR DESCRIPTION
### Summary:

This PR fixes the AttributeDefinition's `validate` and `set` types. It adds the second argument to the `set` and also adds the async return to both of them.

I believe #1012 is related to this issue


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [ ] No
- [x] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `npm run lint`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
