### PR TITLE
Fixes issue when passing in recursive objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "license": "Unlicense",
       "dependencies": {
         "aws-sdk": "^2.968.0",
-        "js-object-utilities": "^2.0.0",
+        "js-object-utilities": "^2.1.0",
         "source-map-support": "^0.5.19",
         "uuid": "^8.3.2"
       },
@@ -2533,9 +2533,9 @@
       }
     },
     "node_modules/js-object-utilities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/js-object-utilities/-/js-object-utilities-2.0.0.tgz",
-      "integrity": "sha512-d0o5Hnd+9q9mswk8VhU9Fzl+QLce3FvtNlLKV7UTUYjAZuChAKeS/DnuameOpiJAXquqrXLJYUcABxhIWogwpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/js-object-utilities/-/js-object-utilities-2.1.0.tgz",
+      "integrity": "sha512-X62npvVTfyNELV4gPU4jJSzFZbdxk3zH/FxlBrZ6n+AGKpGyhMpsPs00tjtqTLy582zG4bvaG5fuKMm/zA1gng==",
       "license": "UNLICENSE"
     },
     "node_modules/js-tokens": {
@@ -5909,9 +5909,9 @@
       "version": "0.15.0"
     },
     "js-object-utilities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/js-object-utilities/-/js-object-utilities-2.0.0.tgz",
-      "integrity": "sha512-d0o5Hnd+9q9mswk8VhU9Fzl+QLce3FvtNlLKV7UTUYjAZuChAKeS/DnuameOpiJAXquqrXLJYUcABxhIWogwpA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/js-object-utilities/-/js-object-utilities-2.1.0.tgz",
+      "integrity": "sha512-X62npvVTfyNELV4gPU4jJSzFZbdxk3zH/FxlBrZ6n+AGKpGyhMpsPs00tjtqTLy582zG4bvaG5fuKMm/zA1gng=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.968.0",
-    "js-object-utilities": "^2.0.0",
+    "js-object-utilities": "^2.1.0",
     "source-map-support": "^0.5.19",
     "uuid": "^8.3.2"
   },

--- a/test/unit/Document.js
+++ b/test/unit/Document.js
@@ -2058,6 +2058,19 @@ describe("Document", () => {
 				"output": {"someField": "hello"},
 				"schema": {"someField": {"type": String, "required": true}, "someFieldAndMore": {"type": String, "required": true}}
 			},
+			{
+				"input": [(() => {
+					let object = {
+						"id": 1
+					};
+					object.array = {"first": 1};
+					object.array2 = object;
+					return object;
+				})(), {"saveUnknown": true}],
+				"output": {"id": 1},
+				"schema": {"id": Number},
+				"inputJSONString": JSON.stringify({"id": 1, "array": {"first": 1}, "array2": "CIRCULAR"})
+			},
 			// Defaults
 			{
 				"input": {},
@@ -2797,12 +2810,13 @@ describe("Document", () => {
 			};
 
 			const testFunc = test.test || it;
+			const inputJSONString = test.inputJSONString || JSON.stringify(test.input);
 			if (test.error) {
-				testFunc(`Should throw error ${JSON.stringify(test.error)} for input of ${JSON.stringify(test.input)}`, () => {
+				testFunc(`Should throw error ${JSON.stringify(test.error)} for input of ${inputJSONString}`, () => {
 					return expect(func().model.objectFromSchema(...func().input)).to.be.rejectedWith(test.error.message);
 				});
 			} else {
-				testFunc(`Should return ${JSON.stringify(test.output)} for input of ${JSON.stringify(test.input)} with a schema of ${JSON.stringify(test.schema)}`, async () => {
+				testFunc(`Should return ${JSON.stringify(test.output)} for input of ${inputJSONString} with a schema of ${JSON.stringify(test.schema)}`, async () => {
 					expect(await func().model.objectFromSchema(...func().input)).to.eql(test.output);
 				});
 			}


### PR DESCRIPTION
### Summary:

This PR fixes an issue when passing in recursive objects into Dynamoose.


<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
// Code here
```

#### Model
```
// Code here
```

#### General
```
// Code here
```


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
#----


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:




### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
