### PR TITLE
Fixing type of AttributeDefinition.default

### DIFF
--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -440,7 +440,7 @@ interface AttributeDefinition {
 	 * }
 	 * ```
 	 */
-	default?: ValueType | (() => ValueType)|(() => Promise<ValueType>);
+	default?: ValueType | (() => ValueType | Promise<ValueType>);
 	/**
 	 * You can set this property to always use the `default` value, even if a value is already set. This can be used for data that will be used as sort or secondary indexes. The default for this property is false.
 	 *

--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -440,7 +440,7 @@ interface AttributeDefinition {
 	 * }
 	 * ```
 	 */
-	default?: ValueType | (() => ValueType);
+	default?: ValueType | (() => ValueType)|(() => Promise<ValueType>);
 	/**
 	 * You can set this property to always use the `default` value, even if a value is already set. This can be used for data that will be used as sort or secondary indexes. The default for this property is false.
 	 *

--- a/test/types/Schema.ts
+++ b/test/types/Schema.ts
@@ -115,3 +115,9 @@ const shouldSucceedWithAsyncValidateMethodSchema = new dynamoose.Schema({
 		"validate": (value) => Promise.resolve(true)
 	}
 });
+const shouldSucceedWithAsyncDefaultMethodSchema = new dynamoose.Schema({
+	"id": {
+		"type": String,
+		"default": () => Promise.resolve("foo")
+	}
+});


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:

When I use async function as default value,I got a type error.
This pull request fixes the bug.




<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema

I got a type error on a scheme like below.

```
new dynamoose.Schema({
	"id": {
		"type": String,
		"default": () => Promise.resolve("foo")
	}
});
```




### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [x] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
-  [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
