### PR TITLE
Propagate the environment when calling npm publish

### DIFF
--- a/publish/publish-npm-subpackages.js
+++ b/publish/publish-npm-subpackages.js
@@ -18,6 +18,7 @@ const path = require("path");
 		console.log(`[${pkg}] npm publish --tag ${process.env.TAG}`);
 		await exec(`npm publish --tag ${process.env.TAG}`, {
 			"env": {
+				...process.env,
 				"NODE_AUTH_TOKEN": process.env.NODE_AUTH_TOKEN
 			},
 			"cwd": path.resolve(__dirname, "..", "workspaces", pkg)


### PR DESCRIPTION
### Summary:

I'm looking into using your library and was trying to find out if v3 would be ready any time soon or not. I read a call for help in https://github.com/dynamoose/dynamoose/discussions/1377 regarding publishing and I probably know the culprit. It's hard for me to test obviously. I can reproduce locally though.

When calling `npm publish` make sure that the current environment variables are also available. Specifically `PATH` needs to be available or else `node` cannot be found. 

## Previously
```
❯ NODE_AUTH_TOKEN=foo TAG=bar node publish/publish-npm-subpackages.js
[dynamoose-utils] Starting publish
/Users/avanleeuwen/.nvm/versions/node/v17.0.1/bin/node

/Users/avanleeuwen/.nvm/versions/node/v17.0.1/bin/npm

v17.0.1

8.1.1

[dynamoose-utils] npm install
[dynamoose-utils] npm publish --tag bar
node:child_process:397
      ex = new Error('Command failed: ' + cmd + '\n' + stderr);
           ^

Error: Command failed: npm publish --tag bar
env: node: No such file or directory

    at ChildProcess.exithandler (node:child_process:397:12)
    at ChildProcess.emit (node:events:390:28)
    at maybeClose (node:internal/child_process:1062:16)
    at Socket.<anonymous> (node:internal/child_process:448:11)
    at Socket.emit (node:events:390:28)
    at Pipe.<anonymous> (node:net:687:12) {
  killed: false,
  code: 127,
  signal: null,
  cmd: 'npm publish --tag bar'
}

Node.js v17.0.1
```

## Afterwards
```
❯ NODE_AUTH_TOKEN=foo TAG=bar node publish/publish-npm-subpackages.js
[dynamoose-utils] Starting publish
/Users/avanleeuwen/.nvm/versions/node/v17.0.1/bin/node

/Users/avanleeuwen/.nvm/versions/node/v17.0.1/bin/npm

v17.0.1

8.1.1

[dynamoose-utils] npm install
[dynamoose-utils] npm publish --tag bar
node:child_process:397
      ex = new Error('Command failed: ' + cmd + '\n' + stderr);
           ^

Error: Command failed: npm publish --tag bar
npm notice
npm notice 📦  dynamoose-utils@3.0.0-beta.2
npm notice === Tarball Contents ===
npm notice 1.2kB LICENSE
npm notice 96B   README.md
npm notice 3.6kB dist/Error.d.ts
npm notice 1.2kB dist/Error.js
npm notice 152B  dist/index.d.ts
npm notice 352B  dist/index.js
npm notice 187B  dist/wildcard_allowed_check.d.ts
npm notice 989B  dist/wildcard_allowed_check.js
npm notice 1.9kB package.json
npm notice === Tarball Details ===
npm notice name:          dynamoose-utils
npm notice version:       3.0.0-beta.2
npm notice filename:      dynamoose-utils-3.0.0-beta.2.tgz
npm notice package size:  2.9 kB
npm notice unpacked size: 9.6 kB
npm notice shasum:        956ef8e249bdd425bdc6335babb02c89965ae148
npm notice integrity:     sha512-QIqXRSSyd/Zhd[...]IaoxO0yisDlsA==
npm notice total files:   9
npm notice
npm ERR! code ENEEDAUTH
npm ERR! need auth This command requires you to be logged in.
npm ERR! need auth You need to authorize this machine using `npm adduser`

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/avanleeuwen/.npm/_logs/2022-03-22T20_43_06_402Z-debug.log

    at ChildProcess.exithandler (node:child_process:397:12)
    at ChildProcess.emit (node:events:390:28)
    at maybeClose (node:internal/child_process:1062:16)
    at Socket.<anonymous> (node:internal/child_process:448:11)
    at Socket.emit (node:events:390:28)
    at Pipe.<anonymous> (node:net:687:12) {
  killed: false,
  code: 1,
  signal: null,
  cmd: 'npm publish --tag bar'
}

Node.js v17.0.1
```

Obviously it fails with an authentication error since I provided the 'auth token' `foo`. 

### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [x] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
