### PR TITLE
fix: add treatment when result.Items is not been returned using DAX

### DIFF
--- a/lib/DocumentRetriever.ts
+++ b/lib/DocumentRetriever.ts
@@ -56,7 +56,7 @@ abstract class DocumentRetriever {
 					[`${this.internalSettings.typeInformation.pastTense}Count`]: result[`${utils.capitalize_first_letter(this.internalSettings.typeInformation.pastTense)}Count`]
 				};
 			}
-			const array: any = (await Promise.all(result.Items.map(async (item) => await new this.internalSettings.model.Document(item, {"type": "fromDynamo"}).conformToSchema({"customTypesDynamo": true, "checkExpiredItem": true, "saveUnknown": true, "modifiers": ["get"], "type": "fromDynamo"})))).filter((a) => Boolean(a));
+			const array: any = (await Promise.all((result.Items || []).map(async (item) => await new this.internalSettings.model.Document(item, {"type": "fromDynamo"}).conformToSchema({"customTypesDynamo": true, "checkExpiredItem": true, "saveUnknown": true, "modifiers": ["get"], "type": "fromDynamo"})))).filter((a) => Boolean(a));
 			array.lastKey = result.LastEvaluatedKey ? Array.isArray(result.LastEvaluatedKey) ? result.LastEvaluatedKey.map((key) => this.internalSettings.model.Document.fromDynamo(key)) : this.internalSettings.model.Document.fromDynamo(result.LastEvaluatedKey) : undefined;
 			array.count = result.Count;
 			array[`${this.internalSettings.typeInformation.pastTense}Count`] = result[`${utils.capitalize_first_letter(this.internalSettings.typeInformation.pastTense)}Count`];


### PR DESCRIPTION
fixes #1386

### Summary:

`DocumentRetriever.prepareForReturn` is throwing `TypeError: Cannot read property 'map' of undefined\n    at prepareForReturn` error when trying to retrieve items (query or scan) using DAX with [amazon-dax-client](https://www.npmjs.com/package/amazon-dax-client). 


### Code sample:
#### Schema
```
const ChatSessionSchema = new dynamoose.Schema(
  {
    chatId: {
      type: String,
      hashKey: true,
      required: true
    },
    id: {
      type: String,
      required: true,
      rangeKey: true,
    },    
    status: {
      type: String,
      required: true,
    }    
  }
);
```

#### Model
```
export type ChatSessionDocument = ChatSession & Document;

const model = dynamoose.model<ChatSessionDocument>(
  'chat-sessions',
  ChatSessionSchema
);

```

#### General
```
const result = model.query('chatId').eq('1234').exec();
```


### Current output and behavior (including stack trace):

`"TypeError: Cannot read property 'map' of undefined\n    at prepareForReturn (/Users/user/project/node_modules/dynamoose/lib/DocumentRetriever.ts:59:55)`

### Expected output and behavior:

```
[
  lastKey: undefined,
  count: 0,
  queriedCount: undefined,
  timesQueried: 1,
  populate: [Function: PopulateDocuments],
  toJSON: [Function: documentToJSON]
]
```

### Environment:

Operating System: MacOS
Operating System Version: macOS Monterey
Node.js version: v14.19.0
NPM version: 6.14.16
Dynamoose version: 2.8.5


### Other information (if applicable):

Using DAX configuration:

```
import * as AmazonDaxClient from 'amazon-dax-client';
import { aws } from 'dynamoose';

...

const dax = new AmazonDaxClient({
      endpoints: [process.env.DYNAMODB_DAX],
      region: process.env.DYNAMODB_REGION,
    });

aws.ddb.set(dax);      
```

Debbuging I noticed that when a retrieving a cached query the amazon-dax-client is returning without Items property:

```
{ Count: 0, ScannedCount: 0 }`
```

When is not cached it works because returns with Items property:

```
{ Items: [], Count: 0, ScannedCount: 0 }
```

`result.Items.map` at line 59 throws error because result.Items does not exist.

### Other:
- [X] I have read through the Dynamoose documentation before posting this issue
- [X] I have searched through the GitHub issues (including closed issues) and pull requests to ensure this issue has not already been raised before
- [X] I have searched the internet and Stack Overflow to ensure this issue hasn't been raised or answered before
- [X] I have tested the code provided and am confident it doesn't work as intended
- [X] I have filled out all fields above
- [X] I am running the latest version of Dynamoose
