### PR TITLE
Fixed typo

### DIFF
--- a/docs/docs/guide/Document.md
+++ b/docs/docs/guide/Document.md
@@ -88,7 +88,7 @@ myUser.delete((error) => {
 
 ## document.populate([settings], [callback])
 
-This allows you to populate a document with document instances for the subdocuments you are referencing in your schema. This function will return a promise, or call the `callback` paramter function upon completion.
+This allows you to populate a document with document instances for the subdocuments you are referencing in your schema. This function will return a promise, or call the `callback` parameter function upon completion.
 
 The `settings` parameter is an object you can pass in with the following properties:
 


### PR DESCRIPTION
There was a typo on line 65.  'parmter' was written instead of 'parameter'.

### Summary:

I noticed what I thought to be a typo while going through the docs. 



