### PR TITLE
Copying README to package folders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         continue-on-error: true
         with:
           base-path: packages/dynamoose
+          path-to-lcov: ./packages/dynamoose/coverage/lcov.info
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
   finalize:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
           node-version: lts/*
           registry-url: https://registry.npmjs.org/
       - run: npm install
+      - run: node publish/copy-readme.js
       - run: lerna publish from-package --dist-tag $TAG --yes --no-git-tag-version --no-push --no-verify-access
         env:
           TAG: ${{ needs.getinfo.outputs.npmtag }}

--- a/publish/copy-readme.js
+++ b/publish/copy-readme.js
@@ -1,0 +1,28 @@
+const fs = require("fs").promises;
+const path = require("path");
+
+(async () => {
+	const packagesContents = await fs.readdir(path.join(__dirname, "..", "packages"));
+	const packages = (await Promise.all(packagesContents.map(async (package) => {
+		const isFolder = (await fs.stat(path.join(__dirname, "..", "packages", package))).isDirectory();
+		return isFolder ? package : null;
+	}))).filter((package) => Boolean(package));
+
+	await Promise.all(packages.map(async (package) => {
+		// Check if the package has a README.md file
+		const readmePath = path.join(__dirname, "..", "packages", package, "README.md");
+		if (!(await fileExists(readmePath))) {
+			// If not, copy the README.md file from the root of the project
+			await fs.copyFile(path.join(__dirname, "..", "README.md"), readmePath);
+		}
+	}));
+})();
+
+const fileExists = async (filePath) => {
+	try {
+		await fs.access(filePath);
+		return true;
+	} catch (e) {
+		return false;
+	}
+};

--- a/publish/copy-readme.js
+++ b/publish/copy-readme.js
@@ -11,7 +11,7 @@ const path = require("path");
 	await Promise.all(packages.map(async (package) => {
 		// Check if the package has a README.md file
 		const readmePath = path.join(__dirname, "..", "packages", package, "README.md");
-		if (!(await fileExists(readmePath))) {
+		if (!await fileExists(readmePath)) {
 			// If not, copy the README.md file from the root of the project
 			await fs.copyFile(path.join(__dirname, "..", "README.md"), readmePath);
 		}


### PR DESCRIPTION
### Summary:

Copying README to package folders before deployment if a README doesn't already exist in that folder.


<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
// Code here
```

#### Model
```
// Code here
```

#### General
```
// Code here
```


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #1416 


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:




### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
