### PR TITLE
Fix return type of ItemSaveSettings

### DIFF
--- a/packages/dynamoose/lib/Item.ts
+++ b/packages/dynamoose/lib/Item.ts
@@ -22,7 +22,7 @@ import CustomError from "./Error";
 
 export interface ItemSaveSettings {
 	overwrite?: boolean;
-	return?: "request" | "Item";
+	return?: "request" | "item";
 	condition?: Condition;
 }
 export interface ItemSettings {

--- a/packages/dynamoose/test/types/Item.ts
+++ b/packages/dynamoose/test/types/Item.ts
@@ -1,0 +1,13 @@
+import {User, UserTypedModel} from "./Model";
+
+const user = new User(UserTypedModel, {"id": "1", "name": "Jane", "age": 30});
+
+const shouldPassSave = user.save();
+const shouldPassSaveWithReturnRequest = user.save({"return": "request"});
+const shouldPassSaveWithReturnItem = user.save({"return": "item"});
+const shouldPassSaveCallback = user.save(() => {});
+const shouldPassSaveWithReturnRequestCallback = user.save({"return": "request"}, () => {});
+const shouldPassSaveWithReturnItemCallback = user.save({"return": "item"}, () => {});
+
+// @ts-expect-error
+const shouldFailWithInvalidReturnType = user.save({"return": "invalid-return-type"});

--- a/packages/dynamoose/test/types/Model.ts
+++ b/packages/dynamoose/test/types/Model.ts
@@ -22,6 +22,8 @@ const model = dynamoose.model("User", {"id": Number});
 const shouldPassTableCreateRequest = model.table.create.request();
 
 const shouldPassCreateWithNoReturnSetting = model.create({"id": 1}, {"overwrite": true});
+const shouldPassCreateWithReturnRequest = model.create({"id": 1}, {"return": "request"});
+const shouldPassCreateWithReturnItem = model.create({"id": 1}, {"return": "item"});
 const shouldPassGetWithNoReturnSetting = model.get({"id": 1}, {"attributes": ["something"]});
 const shouldPassDeleteWithNoReturnSetting = model.delete({"id": 1}, {"condition": new dynamoose.Condition("name").eq("Charlie")});
 const shouldPassUpdateWithNoReturnSetting = model.update({"id": 1}, {"name": "Charlie"}, {"condition": new dynamoose.Condition("name").eq("Bob")});
@@ -44,6 +46,9 @@ const shouldPassGetWithNumberAsKey = model.get(1);
 
 const shouldPassUpdateWithStringAsKey = model.update("id", {"value": "hello world"});
 const shouldPassUpdateWithNumberAsKey = model.update(1, {"value": "hello world"});
+
+// @ts-expect-error
+const shouldFailWithInvalidReturnType = model.create({"id": 1}, {"return": "invalid-return-type"});
 
 // @ts-expect-error
 const shouldFailWithInvalidTransaction = model.transaction.notValid();


### PR DESCRIPTION
### Summary:

Fixes the return type of `ItemSaveSettings`, which used capital "I" `Item` instead of lowercase "i" `item`.

<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #1423


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:




### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
