### PR TITLE
Hotfix: dynamoose.aws.ddb.local() optional param

### DIFF
--- a/packages/dynamoose/lib/aws/ddb/index.ts
+++ b/packages/dynamoose/lib/aws/ddb/index.ts
@@ -4,7 +4,7 @@ export interface DDBInterface {
 	(): DynamoDB.DynamoDB;
 	set: (ddb: DynamoDB.DynamoDB) => void;
 	revert: () => void;
-	local: (endpoint: string) => void;
+	local: (endpoint?: string) => void;
 }
 
 export default function (): DDBInterface {

--- a/packages/dynamoose/test/types/aws/ddb.ts
+++ b/packages/dynamoose/test/types/aws/ddb.ts
@@ -1,0 +1,5 @@
+import * as dynamoose from "../../../dist";
+
+const shouldPassWithParam = dynamoose.aws.ddb.local("http://localhost:8000");
+
+const shouldPassWithoutParams = dynamoose.aws.ddb.local();


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
calling `dynamoose.aws.ddb.local()` was typed with a required parameter whereas it's actually optional (so says the docs and the code)




### Type (select 1):
- [X] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [X] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
