### PR TITLE
Adding TypeScript Types for Table Defaults

### DIFF
--- a/packages/dynamoose/lib/Instance.ts
+++ b/packages/dynamoose/lib/Instance.ts
@@ -1,6 +1,7 @@
 import {AWS} from "./aws";
 import {Model} from "./Model";
 import {Table as PrimaryTable, TableOptionsOptional} from "./Table";
+import {TableOptionsAccessor} from "./Table/defaults";
 
 export interface PrimaryTableInterface extends PrimaryTable {
 	new (name: string, models: Model[], options?: TableOptionsOptional): PrimaryTable;
@@ -10,7 +11,7 @@ export class Instance {
 	static default: Instance = new Instance();
 
 	aws: AWS;
-	Table: PrimaryTableInterface;
+	Table: PrimaryTableInterface & {"defaults": TableOptionsAccessor};
 
 	/**
 	 * This class allows you to create a new instance of Dynamoose, allowing for easy multi-region AWS requests.

--- a/packages/dynamoose/lib/Table/defaults.ts
+++ b/packages/dynamoose/lib/Table/defaults.ts
@@ -30,7 +30,11 @@ export const original: TableOptions = {
 	// "defaultReturnValues": "ALL_NEW",
 };
 let customValue: TableOptionsOptional = {};
-const customObject = {
+export interface TableOptionsAccessor {
+	"set": (val: TableOptionsOptional) => void;
+	"get": () => TableOptionsOptional;
+}
+const customObject: TableOptionsAccessor = {
 	"set": (val: TableOptionsOptional): void => {
 		customValue = val;
 	},

--- a/packages/dynamoose/test/types/Table.ts
+++ b/packages/dynamoose/test/types/Table.ts
@@ -9,3 +9,9 @@ const shouldSucceedWithTagsSetToEmptyObject = new dynamoose.Table("Table", [], {
 
 const shouldAllowForAccessingHashKey = new dynamoose.Table("Table", []).hashKey;
 const shouldAllowForAccessingRangeKey = new dynamoose.Table("Table", []).rangeKey;
+
+const shouldAllowForAccessingTableDefaults = dynamoose.Table.defaults;
+const shouldAllowForGettingTableDefaults = dynamoose.Table.defaults.get();
+const shouldAllowForSettingTableDefaults = dynamoose.Table.defaults.set({
+	"prefix": "MyApp_"
+});


### PR DESCRIPTION
### Summary:

This PR fixes an issue where TypeScript types weren't included for `dynamoose.Table.defaults`.


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #1382 


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
