### PR TITLE
Version 3.0.0 Beta 9

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
 	"packages": [
 		"packages/*"
 	],
-	"version": "3.0.0-beta.8"
+	"version": "3.0.0-beta.9"
 }

--- a/packages/dynamoose-logger/package-lock.json
+++ b/packages/dynamoose-logger/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dynamoose-logger",
-	"version": "3.0.0-beta.8",
+	"version": "3.0.0-beta.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dynamoose-logger",
-			"version": "3.0.0-beta.8",
+			"version": "3.0.0-beta.9",
 			"funding": [
 				{
 					"type": "github-sponsors",

--- a/packages/dynamoose-logger/package.json
+++ b/packages/dynamoose-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose-logger",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "description": "Dynamoose is a modeling tool for Amazon's DynamoDB (inspired by Mongoose)",
   "homepage": "https://dynamoosejs.com",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "dynamoose-utils": "^3.0.0-beta.8",
+    "dynamoose-utils": "^3.0.0-beta.9",
     "js-object-utilities": "^2.1.0",
     "uuid": "^8.3.2"
   },

--- a/packages/dynamoose-utils/package-lock.json
+++ b/packages/dynamoose-utils/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dynamoose-utils",
-	"version": "3.0.0-beta.8",
+	"version": "3.0.0-beta.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dynamoose-utils",
-			"version": "3.0.0-beta.8",
+			"version": "3.0.0-beta.9",
 			"funding": [
 				{
 					"type": "github-sponsors",

--- a/packages/dynamoose-utils/package.json
+++ b/packages/dynamoose-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose-utils",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "description": "Dynamoose is a modeling tool for Amazon's DynamoDB (inspired by Mongoose)",
   "homepage": "https://dynamoosejs.com",
   "main": "dist/index.js",

--- a/packages/dynamoose/package-lock.json
+++ b/packages/dynamoose/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamoose",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamoose",
-      "version": "3.0.0-beta.8",
+      "version": "3.0.0-beta.9",
       "funding": [
         {
           "type": "github-sponsors",

--- a/packages/dynamoose/package.json
+++ b/packages/dynamoose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "description": "Dynamoose is a modeling tool for Amazon's DynamoDB (inspired by Mongoose)",
   "homepage": "https://dynamoosejs.com",
   "main": "dist/index.js",
@@ -27,11 +27,11 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.142.0",
     "@aws-sdk/util-dynamodb": "^3.142.0",
-    "dynamoose-utils": "^3.0.0-beta.8",
+    "dynamoose-utils": "^3.0.0-beta.9",
     "js-object-utilities": "^2.1.0"
   },
   "devDependencies": {
-    "dynamoose-logger": "^3.0.0-beta.8"
+    "dynamoose-logger": "^3.0.0-beta.9"
   },
   "license": "Unlicense",
   "funding": [


### PR DESCRIPTION
## Version 3.0.0 Beta 9

I don't normally provide release notes for beta versions. However, this release contains two important notes I wanted to call out:

- There was previously a breaking change in v3.0.0 that required you to create a `dynamoose.Table` instance. This is **NO** longer the case. We have updated it so that if you create a model without a table, it will automatically create a table instance for you once you make a DynamoDB call on the model. This is done to ensure better backwards compatibility with v2, make migration easier, and overall reduce complexity in Dynamoose for simple use cases.
- Additionally, this beta (beta 9) will likely be one of the last beta release in the v3.0.0 process. Any future betas will very likely be small fixes required after testing v3.0.0 with my personal projects. Thank you for participating in the beta testing of v3.0.0, and I can't wait for the final release of it.