### PR TITLE
Model table create request

### DIFF
--- a/PENDING_CHANGELOG.md
+++ b/PENDING_CHANGELOG.md
@@ -36,7 +36,7 @@ Please comment or [contact me](https://charlie.fish/contact) if you have any que
 	- `dynamoose.NULL` is now `dynamoose.type.NULL`.
 - Stricter validation of Schema types. If you pass in an invalid schema attribute type, it will now throw an error upon initialization.
 	- For example, `new dynamoose.Schema({"id": "random"})` will now throw an error.
-- `Model.table.create.request()` has been replaced by `Model.table.create({"return": "request"})`.
+- `Model.table.create.request()` has been replaced by `Model.table().create({"return": "request"})`.
 - Node.js >=v12 now required.
 - New IAM roles (`listTagsOfResource`, `tagResource`, `untagResource`) required if `update` is set to true.
 - `index.global` property has been removed within Schema Attribute Settings. It has been replaced with `index.type`, which accepts `"global"` or `"local"` as values. This setting remains optional (however, the default value has changed).

--- a/PENDING_CHANGELOG.md
+++ b/PENDING_CHANGELOG.md
@@ -36,6 +36,7 @@ Please comment or [contact me](https://charlie.fish/contact) if you have any que
 	- `dynamoose.NULL` is now `dynamoose.type.NULL`.
 - Stricter validation of Schema types. If you pass in an invalid schema attribute type, it will now throw an error upon initialization.
 	- For example, `new dynamoose.Schema({"id": "random"})` will now throw an error.
+- `Model.table.create.request()` has been replaced by `Model.table.create({"return": "request"})`.
 - Node.js >=v12 now required.
 - New IAM roles (`listTagsOfResource`, `tagResource`, `untagResource`) required if `update` is set to true.
 - `index.global` property has been removed within Schema Attribute Settings. It has been replaced with `index.type`, which accepts `"global"` or `"local"` as values. This setting remains optional (however, the default value has changed).

--- a/docs/docs_src/guide/Model.md
+++ b/docs/docs_src/guide/Model.md
@@ -8,6 +8,10 @@ dyno_jsdoc_dist/Model/index.js|new Model
 
 dyno_jsdoc_dist/Model/index.js|model.name
 
+## model.table
+
+dyno_jsdoc_dist/Model/index.js|model.table
+
 ## model.get(key[, settings][, callback])
 
 You can use Model.get to retrieve a item from DynamoDB. This method uses the `getItem` DynamoDB API call to retrieve the object.

--- a/docs/docs_src/guide/Model.md
+++ b/docs/docs_src/guide/Model.md
@@ -8,7 +8,7 @@ dyno_jsdoc_dist/Model/index.js|new Model
 
 dyno_jsdoc_dist/Model/index.js|model.name
 
-## model.table
+## model.table()
 
 dyno_jsdoc_dist/Model/index.js|model.table
 

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -361,6 +361,24 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 		return this.getInternalProperties(internalProperties).name;
 	}
 
+	/**
+	 * This property will return the [`Table`](Table.md) instance for the model.
+	 *
+	 * If a Table instance hasn't been created yet for this model, it will be created when accessing this property.
+	 *
+	 * This property is unable to be set.
+	 *
+	 * ```js
+	 * const User = dynamoose.model("User", {"id": String});
+	 *
+	 * console.log(User.table.hashKey); // id
+	 * ```
+	 * @readonly
+	 */
+	get table (): Table {
+		return this.getInternalProperties(internalProperties).table();
+	}
+
 	// originalName: string; // Name without prefixes
 	// options: ModelOptions;
 	// schemas: Schema[];

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -362,20 +362,17 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 	}
 
 	/**
-	 * This property will return the [`Table`](Table.md) instance for the model.
+	 * This function will return the [`Table`](Table.md) instance for the model.
 	 *
-	 * If a Table instance hasn't been created yet for this model, it will be created when accessing this property.
-	 *
-	 * This property is unable to be set.
+	 * If a Table instance hasn't been created yet for this model, it will be created when calling this function.
 	 *
 	 * ```js
 	 * const User = dynamoose.model("User", {"id": String});
 	 *
-	 * console.log(User.table.hashKey); // id
+	 * console.log(User.table().hashKey); // id
 	 * ```
-	 * @readonly
 	 */
-	get table (): Table {
+	table (): Table {
 		return this.getInternalProperties(internalProperties).table();
 	}
 

--- a/packages/dynamoose/lib/utils/dynamoose/returnModel.ts
+++ b/packages/dynamoose/lib/utils/dynamoose/returnModel.ts
@@ -9,7 +9,7 @@ export default <T extends Item = AnyItem>(model: Model<T>): ModelType<T> => {
 		Object.keys(model),
 		Object.keys(Object.getPrototypeOf(model)),
 		Object.getOwnPropertyNames(Object.getPrototypeOf(model))
-	]).filter((key) => !["constructor", "name"].includes(key));
+	]).filter((key) => !["constructor", "name", "table"].includes(key));
 	keys.forEach((key) => {
 		if (typeof model[key] === "object") {
 			const main = (key: string): void => {

--- a/packages/dynamoose/lib/utils/dynamoose/returnModel.ts
+++ b/packages/dynamoose/lib/utils/dynamoose/returnModel.ts
@@ -9,7 +9,7 @@ export default <T extends Item = AnyItem>(model: Model<T>): ModelType<T> => {
 		Object.keys(model),
 		Object.keys(Object.getPrototypeOf(model)),
 		Object.getOwnPropertyNames(Object.getPrototypeOf(model))
-	]).filter((key) => !["constructor", "name", "table"].includes(key));
+	]).filter((key) => !["constructor", "name"].includes(key));
 	keys.forEach((key) => {
 		if (typeof model[key] === "object") {
 			const main = (key: string): void => {

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -135,6 +135,32 @@ describe("Model", () => {
 		});
 	});
 
+	describe("model.table()", () => {
+		it("Should return correct value", async () => {
+			const model = dynamoose.model("Cat", {"id": String});
+			expect(model.table().name).toEqual("Cat");
+			expect(await model.table().create({"return": "request"})).toEqual({
+				"AttributeDefinitions": [
+					{
+						"AttributeName": "id",
+						"AttributeType": "S"
+					}
+				],
+				"KeySchema": [
+					{
+						"AttributeName": "id",
+						"KeyType": "HASH"
+					}
+				],
+				"ProvisionedThroughput": {
+					"ReadCapacityUnits": 1,
+					"WriteCapacityUnits": 1
+				},
+				"TableName": "Cat"
+			});
+		});
+	});
+
 	describe("model.get()", () => {
 		let User, getItemParams, getItemFunction;
 		beforeEach(() => {

--- a/packages/dynamoose/test/types/Model.ts
+++ b/packages/dynamoose/test/types/Model.ts
@@ -18,8 +18,6 @@ const shouldNotFailWithConfigurationParameter = dynamoose.model("User", {"id": S
 
 const model = dynamoose.model("User", {"id": Number});
 
-const shouldPassTableCreateRequest = model.table.create.request();
-
 const shouldPassCreateWithNoReturnSetting = model.create({"id": 1}, {"overwrite": true});
 const shouldPassCreateWithReturnRequest = model.create({"id": 1}, {"return": "request"});
 const shouldPassCreateWithReturnItem = model.create({"id": 1}, {"return": "item"});


### PR DESCRIPTION
### Summary:

This PR re-adds support in v3 for the `model.table.create.request` option by changing it to `model.table.create({"return": "request"})`


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
