### PR TITLE
Ability to use aliases/mappings in model.get and model.delete

### DIFF
--- a/docs/docs_src/guide/Model.md
+++ b/docs/docs_src/guide/Model.md
@@ -107,6 +107,18 @@ User.get({"id": 1}, (error, myUser) => {
 });
 ```
 
+If you are using [`map`](Schema#map-string--string) or [`alias`](Schema#alias-string--string) attribute settings on the key, then you can also use those properties in your call
+```js
+const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
+
+try {
+	const myUser = await User.get({"email": "joe@example.com"});
+	console.log(myUser);
+} catch (error) {
+	console.error(error);
+}
+```
+
 ## model.batchGet(keys[, settings][, callback])
 
 You can use Model.batchGet to retrieve multiple items from DynamoDB. This method uses the `batchGetItem` DynamoDB API call to retrieve the object.
@@ -483,6 +495,18 @@ User.delete({"id": 1}, (error) => {
 		console.log("Successfully deleted item");
 	}
 });
+```
+
+If you are using [`map`](Schema#map-string--string) or [`alias`](Schema#alias-string--string) attribute settings on the key, then you can also use those properties in your call
+```js
+const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
+
+try {
+	await User.delete({"email": "joe@example.com"});
+	console.log("Successfully deleted item");
+} catch (error) {
+	console.error(error);
+}
 ```
 
 ## model.batchDelete(keys[, settings][, callback])

--- a/docs/docs_src/guide/Model.md
+++ b/docs/docs_src/guide/Model.md
@@ -107,18 +107,6 @@ User.get({"id": 1}, (error, myUser) => {
 });
 ```
 
-If you are using [`map`](Schema#map-string--string) or [`alias`](Schema#alias-string--string) attribute settings on the key, then you can also use those properties in your call
-```js
-const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
-
-try {
-	const myUser = await User.get({"email": "joe@example.com"});
-	console.log(myUser);
-} catch (error) {
-	console.error(error);
-}
-```
-
 ## model.batchGet(keys[, settings][, callback])
 
 You can use Model.batchGet to retrieve multiple items from DynamoDB. This method uses the `batchGetItem` DynamoDB API call to retrieve the object.
@@ -495,18 +483,6 @@ User.delete({"id": 1}, (error) => {
 		console.log("Successfully deleted item");
 	}
 });
-```
-
-If you are using [`map`](Schema#map-string--string) or [`alias`](Schema#alias-string--string) attribute settings on the key, then you can also use those properties in your call
-```js
-const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
-
-try {
-	await User.delete({"email": "joe@example.com"});
-	console.log("Successfully deleted item");
-} catch (error) {
-	console.error(error);
-}
 ```
 
 ## model.batchDelete(keys[, settings][, callback])

--- a/packages/dynamoose/lib/Condition.ts
+++ b/packages/dynamoose/lib/Condition.ts
@@ -10,7 +10,7 @@ import {Model} from "./Model";
 import {InternalPropertiesClass} from "./InternalPropertiesClass";
 const {internalProperties} = Internal.General;
 
-const isRawConditionObject = (object): boolean => Object.keys(object).length === 3 && ["ExpressionAttributeValues", "ExpressionAttributeNames"].every((item) => Boolean(object[item]) && typeof object[item] === "object");
+export const isRawConditionObject = (object): boolean => Object.keys(object).length === 3 && ["ExpressionAttributeValues", "ExpressionAttributeNames"].every((item) => Boolean(object[item]) && typeof object[item] === "object");
 
 export type ConditionFunction = (condition: Condition) => Condition;
 // TODO: There is a problem where you can have multiple keys in one `ConditionStorageType`, which will cause problems. We need to fix that. Likely be refactoring it so that the key is part of `ConditionsConditionStorageObject`.

--- a/packages/dynamoose/lib/Condition.ts
+++ b/packages/dynamoose/lib/Condition.ts
@@ -10,7 +10,7 @@ import {Model} from "./Model";
 import {InternalPropertiesClass} from "./InternalPropertiesClass";
 const {internalProperties} = Internal.General;
 
-export const isRawConditionObject = (object): boolean => Object.keys(object).length === 3 && ["ExpressionAttributeValues", "ExpressionAttributeNames"].every((item) => Boolean(object[item]) && typeof object[item] === "object");
+const isRawConditionObject = (object): boolean => Object.keys(object).length === 3 && ["ExpressionAttributeValues", "ExpressionAttributeNames"].every((item) => Boolean(object[item]) && typeof object[item] === "object");
 
 export type ConditionFunction = (condition: Condition) => Condition;
 // TODO: There is a problem where you can have multiple keys in one `ConditionStorageType`, which will cause problems. We need to fix that. Likely be refactoring it so that the key is part of `ConditionsConditionStorageObject`.

--- a/packages/dynamoose/lib/Item.ts
+++ b/packages/dynamoose/lib/Item.ts
@@ -517,7 +517,7 @@ export class AnyItem extends Item {
 // This function will mutate the object passed in to run any actions to conform to the schema that cannot be achieved through non mutating methods in Item.objectFromSchema (setting timestamps, etc.)
 Item.prepareForObjectFromSchema = async function<T extends InternalPropertiesClass<any>>(object: T, model: Model<Item>, settings: ItemObjectFromSchemaSettings): Promise<T> {
 	if (settings.updateTimestamps) {
-		const schema: Schema = await model.getInternalProperties(internalProperties).schemaForObject(object);
+		const schema: Schema = model.getInternalProperties(internalProperties).schemaForObject(object);
 		if (schema.getInternalProperties(internalProperties).settings.timestamps && settings.type === "toDynamo") {
 			const date = Date.now();
 
@@ -540,7 +540,7 @@ Item.prepareForObjectFromSchema = async function<T extends InternalPropertiesCla
 // This function will return a list of attributes combining both the schema attributes with the item attributes. This also takes into account all attributes that could exist (ex. properties in sets that don't exist in item), adding the indexes for each item in the item set.
 // https://stackoverflow.com/a/59928314/894067
 Item.attributesWithSchema = async function (item: Item, model: Model<Item>): Promise<string[]> {
-	const schema: Schema = await model.getInternalProperties(internalProperties).schemaForObject(item);
+	const schema: Schema = model.getInternalProperties(internalProperties).schemaForObject(item);
 	const attributes = schema.attributes();
 	// build a tree out of schema attributes
 	const root = {};
@@ -609,7 +609,7 @@ Item.objectFromSchema = async function (object: any, model: Model<Item>, setting
 	}
 
 	let returnObject = utils.deep_copy(object);
-	const schema: Schema = settings.schema || await model.getInternalProperties(internalProperties).schemaForObject(returnObject);
+	const schema: Schema = settings.schema || model.getInternalProperties(internalProperties).schemaForObject(returnObject);
 	const schemaAttributes = schema.attributes(returnObject);
 
 	function mapAttributes (type: "toDynamo" | "fromDynamo") {
@@ -880,7 +880,7 @@ Item.prototype.conformToSchema = async function (this: Item, settings: ItemObjec
 	const expectedKeys = Object.keys(expectedObject);
 
 	if (settings.mapAttributes) {
-		const schema = await model.getInternalProperties(internalProperties).schemaForObject(expectedObject);
+		const schema = model.getInternalProperties(internalProperties).schemaForObject(expectedObject);
 		const schemaInternalProperties = schema.getInternalProperties(internalProperties);
 		const mapSettingObject = schemaInternalProperties.getMapSettingObject();
 

--- a/packages/dynamoose/lib/ItemRetriever.ts
+++ b/packages/dynamoose/lib/ItemRetriever.ts
@@ -8,7 +8,6 @@ import {CallbackType, ItemArray, ObjectType, SortOrder} from "./General";
 import {PopulateItems} from "./Populate";
 import Internal from "./Internal";
 import {InternalPropertiesClass} from "./InternalPropertiesClass";
-
 const {internalProperties} = Internal.General;
 
 enum ItemRetrieverTypes {

--- a/packages/dynamoose/lib/ItemRetriever.ts
+++ b/packages/dynamoose/lib/ItemRetriever.ts
@@ -129,6 +129,7 @@ abstract class ItemRetriever extends InternalPropertiesClass<ItemRetrieverIntern
 
 	constructor (model: Model<Item>, typeInformation: ItemRetrieverTypeInformation, object?: ConditionInitializer) {
 		super();
+
 		let condition: Condition;
 		try {
 			condition = new Condition(object);

--- a/packages/dynamoose/lib/ItemRetriever.ts
+++ b/packages/dynamoose/lib/ItemRetriever.ts
@@ -268,7 +268,6 @@ ItemRetriever.prototype.getRequest = async function (this: ItemRetriever): Promi
 
 	return object;
 };
-
 interface ItemRetrieverResponse<T> extends ItemArray<T> {
 	lastKey?: ObjectType;
 	count: number;

--- a/packages/dynamoose/lib/ItemRetriever.ts
+++ b/packages/dynamoose/lib/ItemRetriever.ts
@@ -1,14 +1,13 @@
-import {BasicOperators, Condition, ConditionInitializer} from "./Condition";
-import {CallbackType, ItemArray, ObjectType, SortOrder} from "./General";
-
+import ddb from "./aws/ddb/internal";
 import CustomError from "./Error";
+import utils from "./utils";
+import {Model} from "./Model";
+import {Item} from "./Item";
+import {CallbackType, ItemArray, ObjectType, SortOrder} from "./General";
+import {PopulateItems} from "./Populate";
 import Internal from "./Internal";
 import {InternalPropertiesClass} from "./InternalPropertiesClass";
-import {Item} from "./Item";
-import {Model} from "./Model";
-import {PopulateItems} from "./Populate";
-import ddb from "./aws/ddb/internal";
-import utils from "./utils";
+import {BasicOperators, Condition, ConditionInitializer} from "./Condition";
 
 const {internalProperties} = Internal.General;
 

--- a/packages/dynamoose/lib/ItemRetriever.ts
+++ b/packages/dynamoose/lib/ItemRetriever.ts
@@ -1,13 +1,15 @@
-import ddb from "./aws/ddb/internal";
+import {BasicOperators, Condition, ConditionInitializer} from "./Condition";
+import {CallbackType, ItemArray, ObjectType, SortOrder} from "./General";
+
 import CustomError from "./Error";
-import utils from "./utils";
-import {Condition, ConditionInitializer, BasicOperators} from "./Condition";
-import {Model} from "./Model";
-import {Item} from "./Item";
-import {CallbackType, ObjectType, ItemArray, SortOrder} from "./General";
-import {PopulateItems} from "./Populate";
 import Internal from "./Internal";
 import {InternalPropertiesClass} from "./InternalPropertiesClass";
+import {Item} from "./Item";
+import {Model} from "./Model";
+import {PopulateItems} from "./Populate";
+import ddb from "./aws/ddb/internal";
+import utils from "./utils";
+
 const {internalProperties} = Internal.General;
 
 enum ItemRetrieverTypes {
@@ -129,10 +131,10 @@ abstract class ItemRetriever extends InternalPropertiesClass<ItemRetrieverIntern
 
 	constructor (model: Model<Item>, typeInformation: ItemRetrieverTypeInformation, object?: ConditionInitializer) {
 		super();
-
+		const mappedObj = mapFilter(model, object);
 		let condition: Condition;
 		try {
-			condition = new Condition(object);
+			condition = new Condition(mappedObj);
 		} catch (e) {
 			e.message = `${e.message.replace(" is invalid.", "")} is invalid for the ${typeInformation.type} operation.`;
 			throw e;
@@ -273,6 +275,39 @@ ItemRetriever.prototype.getRequest = async function (this: ItemRetriever): Promi
 
 	return object;
 };
+
+const mapFilter = (model: Model<Item>, object: ConditionInitializer): ConditionInitializer => {
+	// Map the ConditionInitializer into a pseudo-object to help find its schema and thus mapped attributes
+	const pseudoObject = {};
+	if (typeof object === "object" && !(object instanceof Condition)) {
+		Object.keys(object).forEach((key) => pseudoObject[key] = null);
+	} else if (typeof object === "string") {
+		pseudoObject[object] = null;
+	}
+	const schema = model.getInternalProperties(internalProperties).schemaForObject(pseudoObject);
+	const aliasMap = schema.getInternalProperties(internalProperties).getMapSettingObject();
+	let mappedObj: ConditionInitializer;
+	if (typeof object === "object" && !(object instanceof Condition)) {
+		mappedObj = {};
+		Object.keys(object).forEach((key) => {
+			if (key in aliasMap) {
+				mappedObj[aliasMap[key]] = object[key];
+			} else {
+				mappedObj[key] = object[key];
+			}
+		});
+	} else if (typeof object === "string") {
+		if (object in aliasMap) {
+			mappedObj = aliasMap[object];
+		} else {
+			mappedObj = object;
+		}
+	} else {
+		mappedObj = object;
+	}
+	return mappedObj;
+};
+
 interface ItemRetrieverResponse<T> extends ItemArray<T> {
 	lastKey?: ObjectType;
 	count: number;
@@ -345,6 +380,20 @@ export class Query<T> extends ItemRetriever {
 		this.getInternalProperties(internalProperties).settings.sort = order;
 		return this;
 	}
+	filter (key: string): Query<T> {
+		const mappedKey = mapFilter(this.getInternalProperties(internalProperties).internalSettings.model, key);
+		const newCondition = this.getInternalProperties(internalProperties).settings.condition.where(mappedKey as string);
+		this.setInternalProperties(internalProperties, {
+			"internalSettings": this.getInternalProperties(internalProperties).internalSettings,
+			"settings": {
+				"condition": newCondition
+			}
+		});
+		return this;
+	}
+
+	where = this.filter;
+	attribute = this.filter;
 
 	constructor (model: Model<Item>, object?: ConditionInitializer) {
 		super(model, {"type": ItemRetrieverTypes.query, "pastTense": "queried"}, object);

--- a/packages/dynamoose/lib/ItemRetriever.ts
+++ b/packages/dynamoose/lib/ItemRetriever.ts
@@ -129,7 +129,6 @@ abstract class ItemRetriever extends InternalPropertiesClass<ItemRetrieverIntern
 
 	constructor (model: Model<Item>, typeInformation: ItemRetrieverTypeInformation, object?: ConditionInitializer) {
 		super();
-		// const mappedObj = mapFilter(model, object);
 		let condition: Condition;
 		try {
 			condition = new Condition(object);

--- a/packages/dynamoose/lib/ItemRetriever.ts
+++ b/packages/dynamoose/lib/ItemRetriever.ts
@@ -1,13 +1,13 @@
 import ddb from "./aws/ddb/internal";
 import CustomError from "./Error";
 import utils from "./utils";
+import {BasicOperators, Condition, ConditionInitializer} from "./Condition";
 import {Model} from "./Model";
 import {Item} from "./Item";
 import {CallbackType, ItemArray, ObjectType, SortOrder} from "./General";
 import {PopulateItems} from "./Populate";
 import Internal from "./Internal";
 import {InternalPropertiesClass} from "./InternalPropertiesClass";
-import {BasicOperators, Condition, ConditionInitializer} from "./Condition";
 
 const {internalProperties} = Internal.General;
 

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -1,24 +1,22 @@
-import * as DynamoDB from "@aws-sdk/client-dynamodb";
-
-import {AnyItem, Item as ItemCarrier, ItemObjectFromSchemaSettings, ItemSaveSettings, ItemSettings} from "../Item";
-import {CallbackType, FunctionType, InputKey, ItemArray, KeyObject, ModelType, ObjectType} from "../General";
-import {Condition, ConditionInitializer} from "../Condition";
-import {ConditionTransactionInput, CreateTransactionInput, DeleteTransactionInput, GetTransactionInput, UpdateTransactionInput} from "../Transaction";
-import {DynamoDBSetTypeResult, IndexItem, Schema, SchemaDefinition, TableIndex, ValueType} from "../Schema";
-import {Query, Scan} from "../ItemRetriever";
-import {Serializer, SerializerOptions} from "../Serializer";
-import {Table, TableOptionsOptional} from "../Table";
-
-import {AttributeMap} from "../Types";
 import CustomError from "../Error";
-import {Instance} from "../Instance";
-import Internal from "../Internal";
-import {InternalPropertiesClass} from "../InternalPropertiesClass";
-import {PopulateItems} from "../Populate";
-import ddb from "../aws/ddb/internal";
-import returnModel from "../utils/dynamoose/returnModel";
-import type from "../type";
+import {DynamoDBSetTypeResult, IndexItem, Schema, SchemaDefinition, TableIndex, ValueType} from "../Schema";
+import {AnyItem, Item as ItemCarrier, ItemObjectFromSchemaSettings, ItemSaveSettings, ItemSettings} from "../Item";
 import utils from "../utils";
+import ddb from "../aws/ddb/internal";
+import Internal from "../Internal";
+import {Serializer, SerializerOptions} from "../Serializer";
+import {Condition, ConditionInitializer} from "../Condition";
+import {Query, Scan} from "../ItemRetriever";
+import {CallbackType, FunctionType, InputKey, ItemArray, KeyObject, ModelType, ObjectType} from "../General";
+import {PopulateItems} from "../Populate";
+import {AttributeMap} from "../Types";
+import * as DynamoDB from "@aws-sdk/client-dynamodb";
+import {ConditionTransactionInput, CreateTransactionInput, DeleteTransactionInput, GetTransactionInput, UpdateTransactionInput} from "../Transaction";
+import {Table, TableOptionsOptional} from "../Table";
+import type from "../type";
+import {InternalPropertiesClass} from "../InternalPropertiesClass";
+import {Instance} from "../Instance";
+import returnModel from "../utils/dynamoose/returnModel";
 const {internalProperties} = Internal.General;
 
 // Transactions

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -1,22 +1,24 @@
-import CustomError from "../Error";
-import {Schema, SchemaDefinition, DynamoDBSetTypeResult, ValueType, IndexItem, TableIndex} from "../Schema";
-import {Item as ItemCarrier, ItemSaveSettings, ItemSettings, ItemObjectFromSchemaSettings, AnyItem} from "../Item";
-import utils from "../utils";
-import ddb from "../aws/ddb/internal";
-import Internal from "../Internal";
-import {Serializer, SerializerOptions} from "../Serializer";
-import {Condition, ConditionInitializer} from "../Condition";
-import {Scan, Query} from "../ItemRetriever";
-import {CallbackType, ObjectType, FunctionType, ItemArray, ModelType, KeyObject, InputKey} from "../General";
-import {PopulateItems} from "../Populate";
-import {AttributeMap} from "../Types";
 import * as DynamoDB from "@aws-sdk/client-dynamodb";
-import {GetTransactionInput, CreateTransactionInput, DeleteTransactionInput, UpdateTransactionInput, ConditionTransactionInput} from "../Transaction";
+
+import {AnyItem, Item as ItemCarrier, ItemObjectFromSchemaSettings, ItemSaveSettings, ItemSettings} from "../Item";
+import {CallbackType, FunctionType, InputKey, ItemArray, KeyObject, ModelType, ObjectType} from "../General";
+import {Condition, ConditionInitializer} from "../Condition";
+import {ConditionTransactionInput, CreateTransactionInput, DeleteTransactionInput, GetTransactionInput, UpdateTransactionInput} from "../Transaction";
+import {DynamoDBSetTypeResult, IndexItem, Schema, SchemaDefinition, TableIndex, ValueType} from "../Schema";
+import {Query, Scan} from "../ItemRetriever";
+import {Serializer, SerializerOptions} from "../Serializer";
 import {Table, TableOptionsOptional} from "../Table";
-import type from "../type";
-import {InternalPropertiesClass} from "../InternalPropertiesClass";
+
+import {AttributeMap} from "../Types";
+import CustomError from "../Error";
 import {Instance} from "../Instance";
+import Internal from "../Internal";
+import {InternalPropertiesClass} from "../InternalPropertiesClass";
+import {PopulateItems} from "../Populate";
+import ddb from "../aws/ddb/internal";
 import returnModel from "../utils/dynamoose/returnModel";
+import type from "../type";
+import utils from "../utils";
 const {internalProperties} = Internal.General;
 
 // Transactions
@@ -102,7 +104,7 @@ interface ModelInternalProperties {
 	getIndexes: () => Promise<{GlobalSecondaryIndexes?: IndexItem[]; LocalSecondaryIndexes?: IndexItem[]; TableIndex?: any}>;
 	convertKeyToObject: (key: InputKey) => Promise<KeyObject>;
 	schemaCorrectnessScores: (object: ObjectType) => number[];
-	schemaForObject: (object: ObjectType) => Promise<Schema>;
+	schemaForObject: (object: ObjectType) => Schema;
 	getCreateTableAttributeParams: () => Promise<Pick<DynamoDB.CreateTableInput, "AttributeDefinitions" | "KeySchema" | "GlobalSecondaryIndexes" | "LocalSecondaryIndexes">>;
 	getHashKey: () => string;
 	getRangeKey: () => string | void;
@@ -237,7 +239,7 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 				return schemaCorrectnessScores;
 			},
 			// This function returns the best matched schema for the given object input
-			"schemaForObject": async (object: ObjectType): Promise<Schema> => {
+			"schemaForObject": (object: ObjectType): Schema => {
 				const schemaCorrectnessScores = this.getInternalProperties(internalProperties).schemaCorrectnessScores(object);
 				const highestSchemaCorrectnessScoreIndex: number = schemaCorrectnessScores.indexOf(Math.max(...schemaCorrectnessScores));
 

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -1,25 +1,22 @@
-import * as DynamoDB from "@aws-sdk/client-dynamodb";
-
-import {AnyItem, Item as ItemCarrier, ItemObjectFromSchemaSettings, ItemSaveSettings, ItemSettings} from "../Item";
-import {CallbackType, FunctionType, InputKey, ItemArray, KeyObject, ModelType, ObjectType} from "../General";
-import {Condition, ConditionInitializer} from "../Condition";
-import {ConditionTransactionInput, CreateTransactionInput, DeleteTransactionInput, GetTransactionInput, UpdateTransactionInput} from "../Transaction";
-import {DynamoDBSetTypeResult, IndexItem, Schema, SchemaDefinition, TableIndex, ValueType} from "../Schema";
-import {Query, Scan} from "../ItemRetriever";
-import {Serializer, SerializerOptions} from "../Serializer";
-import {Table, TableOptionsOptional} from "../Table";
-
-import {AttributeMap} from "../Types";
 import CustomError from "../Error";
-import {Instance} from "../Instance";
-import Internal from "../Internal";
-import {InternalPropertiesClass} from "../InternalPropertiesClass";
-import {PopulateItems} from "../Populate";
-import ddb from "../aws/ddb/internal";
-import returnModel from "../utils/dynamoose/returnModel";
-import type from "../type";
+import {Schema, SchemaDefinition, DynamoDBSetTypeResult, ValueType, IndexItem, TableIndex} from "../Schema";
+import {Item as ItemCarrier, ItemSaveSettings, ItemSettings, ItemObjectFromSchemaSettings, AnyItem} from "../Item";
 import utils from "../utils";
-
+import ddb from "../aws/ddb/internal";
+import Internal from "../Internal";
+import {Serializer, SerializerOptions} from "../Serializer";
+import {Condition, ConditionInitializer} from "../Condition";
+import {Scan, Query} from "../ItemRetriever";
+import {CallbackType, ObjectType, FunctionType, ItemArray, ModelType, KeyObject, InputKey} from "../General";
+import {PopulateItems} from "../Populate";
+import {AttributeMap} from "../Types";
+import * as DynamoDB from "@aws-sdk/client-dynamodb";
+import {GetTransactionInput, CreateTransactionInput, DeleteTransactionInput, UpdateTransactionInput, ConditionTransactionInput} from "../Transaction";
+import {Table, TableOptionsOptional} from "../Table";
+import type from "../type";
+import {InternalPropertiesClass} from "../InternalPropertiesClass";
+import {Instance} from "../Instance";
+import returnModel from "../utils/dynamoose/returnModel";
 const {internalProperties} = Internal.General;
 
 // Transactions

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -11,7 +11,8 @@ import {CallbackType, ObjectType, FunctionType, ItemArray, ModelType, KeyObject,
 import {PopulateItems} from "../Populate";
 import {AttributeMap} from "../Types";
 import * as DynamoDB from "@aws-sdk/client-dynamodb";
-import {GetTransactionInput, CreateTransactionInput, DeleteTransactionInput, UpdateTransactionInput, ConditionTransactionInput} from "../Transaction";import {Table, TableOptionsOptional} from "../Table";
+import {GetTransactionInput, CreateTransactionInput, DeleteTransactionInput, UpdateTransactionInput, ConditionTransactionInput} from "../Transaction";
+import {Table, TableOptionsOptional} from "../Table";
 import type from "../type";
 import {InternalPropertiesClass} from "../InternalPropertiesClass";
 import {Instance} from "../Instance";

--- a/packages/dynamoose/test/Condition.js
+++ b/packages/dynamoose/test/Condition.js
@@ -258,7 +258,8 @@ describe("Condition", () => {
 								"instance": Instance.default
 							})
 						}),
-						"schemaForObject": () => new dynamoose.Schema({"id": String})
+						"schemaForObject": () => new dynamoose.Schema({"id": String}),
+						"dynamoPropertyForAttribute": (key) => key
 					})
 				};
 				if (test.error) {

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -369,7 +369,7 @@ describe("Model", () => {
 					});
 				});
 
-				it("Should send correct params to getItem if we use a mapped/aliased attribute as the key", async () => {
+				it("Should send correct params to getItem if we use an aliased attribute as the key", async () => {
 					User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
 					new dynamoose.Table("User", [User]);
 
@@ -1177,7 +1177,7 @@ describe("Model", () => {
 					});
 				});
 
-				it("Should send correct params to batchGetItem if we use a mapped/aliased attribute as the key", async () => {
+				it("Should send correct params to batchGetItem if we use an aliased attribute as the key", async () => {
 					User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
 					new dynamoose.Table("User", [User]);
 
@@ -3001,6 +3001,60 @@ describe("Model", () => {
 					});
 				});
 
+				it("Should send correct params to updateItem if we use an aliased attribute for the key with a separate update object", async () => {
+					User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}, "name": String});
+					new dynamoose.Table("User", [User]);
+
+					updateItemFunction = () => Promise.resolve({});
+					await callType.func(User).bind(User)({"email": "john@john.com"}, {"name": "John"});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams).toEqual({
+						"ExpressionAttributeNames": {
+							"#a0": "name"
+						},
+						"ExpressionAttributeValues": {
+							":v0": {
+								"S": "John"
+							}
+						},
+						"UpdateExpression": "SET #a0 = :v0",
+						"Key": {
+							"pk": {
+								"S": "john@john.com"
+							}
+						},
+						"TableName": "User",
+						"ReturnValues": "ALL_NEW"
+					});
+				});
+
+				it("Should send correct params to updateItem if we use an aliased attribute for the key in a single update object", async () => {
+					User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}, "name": String});
+					new dynamoose.Table("User", [User]);
+
+					updateItemFunction = () => Promise.resolve({});
+					await callType.func(User).bind(User)({"email": "john@john.com", "name": "John"});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams).toEqual({
+						"ExpressionAttributeNames": {
+							"#a0": "name"
+						},
+						"ExpressionAttributeValues": {
+							":v0": {
+								"S": "John"
+							}
+						},
+						"UpdateExpression": "SET #a0 = :v0",
+						"Key": {
+							"pk": {
+								"S": "john@john.com"
+							}
+						},
+						"TableName": "User",
+						"ReturnValues": "ALL_NEW"
+					});
+				});
+
 				it.skip("Should throw an error when passing in incorrect type in key", () => {
 					updateItemFunction = () => Promise.resolve({});
 					return expect(callType.func(User).bind(User)("random", {"name": "Charlie"})).rejects.toEqual(new CustomError.TypeMismatch("Expected id to be of type number, instead found type string."));
@@ -3876,7 +3930,7 @@ describe("Model", () => {
 					});
 				});
 
-				it("Should send correct params to deleteItem if we use a mapped/aliased attribute as the key", async () => {
+				it("Should send correct params to deleteItem if we use an aliased attribute as the key", async () => {
 					User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
 					new dynamoose.Table("User", [User]);
 
@@ -4067,7 +4121,7 @@ describe("Model", () => {
 					});
 				});
 
-				it("Should send correct params to batchWriteItem if we use a mapped/aliased attribute as the key", async () => {
+				it("Should send correct params to batchWriteItem if we use an aliased attribute as the key", async () => {
 					User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
 					new dynamoose.Table("User", [User]);
 

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -369,6 +369,23 @@ describe("Model", () => {
 					});
 				});
 
+				it("Should send correct params to getItem if we use a mapped/aliased attribute as the key", async () => {
+					User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
+					new dynamoose.Table("User", [User]);
+
+					getItemFunction = () => Promise.resolve({"Item": {"pk": {"S": "john@john.com"}}});
+					await callType.func(User).bind(User)({"email": "john@john.com"});
+					expect(getItemParams).toBeInstanceOf(Object);
+					expect(getItemParams).toEqual({
+						"Key": {
+							"pk": {
+								"S": "john@john.com"
+							}
+						},
+						"TableName": "User"
+					});
+				});
+
 				it.skip("Should throw an error when passing in incorrect type in key", () => {
 					getItemFunction = () => Promise.resolve({"Item": {"id": {"N": "2"}, "name": {"S": "Charlie"}}});
 					return expect(callType.func(User).bind(User)({"id": "Hello"})).rejects.toEqual(new CustomError.TypeMismatch("Expected id to be of type number, instead found type string."));
@@ -1154,6 +1171,25 @@ describe("Model", () => {
 								"Keys": [
 									{"id": {"N": "2"}},
 									{"id": {"N": "3"}}
+								]
+							}
+						}
+					});
+				});
+
+				it("Should send correct params to batchGetItem if we use a mapped/aliased attribute as the key", async () => {
+					User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
+					new dynamoose.Table("User", [User]);
+
+					promiseFunction = () => Promise.resolve({"Responses": {"User": [{"pk": {"S": "john@john.com"}}, {"pk": {"S": "bob@bob.com"}}]}, "UnprocessedKeys": {}});
+					await callType.func(User).bind(User)([{"email": "john@john.com"}, {"email": "bob@bob.com"}]);
+					expect(params).toBeInstanceOf(Object);
+					expect(params).toEqual({
+						"RequestItems": {
+							"User": {
+								"Keys": [
+									{"pk": {"S": "john@john.com"}},
+									{"pk": {"S": "bob@bob.com"}}
 								]
 							}
 						}
@@ -3840,6 +3876,23 @@ describe("Model", () => {
 					});
 				});
 
+				it("Should send correct params to deleteItem if we use a mapped/aliased attribute as the key", async () => {
+					User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
+					new dynamoose.Table("User", [User]);
+
+					deleteItemFunction = () => Promise.resolve();
+					await callType.func(User).bind(User)({"email": "john@john.com"});
+					expect(deleteItemParams).toBeInstanceOf(Object);
+					expect(deleteItemParams).toEqual({
+						"Key": {
+							"pk": {
+								"S": "john@john.com"
+							}
+						},
+						"TableName": "User"
+					});
+				});
+
 				it.skip("Should throw an error when passing in incorrect type in key", () => {
 					deleteItemFunction = () => Promise.resolve();
 					return expect(callType.func(User).bind(User)({"id": "random"})).rejects.toEqual(new CustomError.TypeMismatch("Expected id to be of type number, instead found type string."));
@@ -4007,6 +4060,31 @@ describe("Model", () => {
 								{
 									"DeleteRequest": {
 										"Key": {"id": {"N": "3"}}
+									}
+								}
+							]
+						}
+					});
+				});
+
+				it("Should send correct params to batchWriteItem if we use a mapped/aliased attribute as the key", async () => {
+					User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
+					new dynamoose.Table("User", [User]);
+
+					promiseFunction = () => Promise.resolve({"UnprocessedItems": {}});
+					await callType.func(User).bind(User)([{"email": "john@john.com"}, {"email": "bob@bob.com"}]);
+					expect(params).toBeInstanceOf(Object);
+					expect(params).toEqual({
+						"RequestItems": {
+							"User": [
+								{
+									"DeleteRequest": {
+										"Key": {"pk": {"S": "john@john.com"}}
+									}
+								},
+								{
+									"DeleteRequest": {
+										"Key": {"pk": {"S": "bob@bob.com"}}
 									}
 								}
 							]

--- a/packages/dynamoose/test/Query.js
+++ b/packages/dynamoose/test/Query.js
@@ -188,6 +188,40 @@ describe("Query", () => {
 					});
 				});
 
+				it.skip("Should send correct request on query.exec if querying main key with aliased name", async () => {
+					const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
+					new dynamoose.Table("User", [User]);
+					await callType.func(User.query("email").eq("john@john.com").exec).bind(User.query("email").eq("john@john.com"))();
+					expect(queryParams).toEqual({
+						"TableName": "User",
+						"ExpressionAttributeNames": {
+							"#qha": "pk"
+						},
+						"ExpressionAttributeValues": {
+							":qhv": {"S": "john@john.com"}
+						},
+						"KeyConditionExpression": "#qha = :qhv"
+					});
+				});
+
+				it.skip("Should send correct request on query.exec if querying main key with range key using aliased names", async () => {
+					const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}, "sk": {"type": String, "alias": "name", "rangeKey": true}});
+					new dynamoose.Table("User", [User]);
+					await callType.func(User.query("email").eq("john@john.com").where("name").eq("John").exec).bind(User.query("email").eq("john@john.com").where("name").eq("John"))();
+					expect(queryParams).toEqual({
+						"TableName": "User",
+						"ExpressionAttributeNames": {
+							"#qha": "pk",
+							"#qra": "sk"
+						},
+						"ExpressionAttributeValues": {
+							":qhv": {"S": "john@john.com"},
+							":qrv": {"S": "John"}
+						},
+						"KeyConditionExpression": "#qha = :qhv AND #qra = :qrv"
+					});
+				});
+
 				it("Should send correct request on query.exec if querying main key with range key", async () => {
 					queryPromiseResolver = () => ({"Items": []});
 					Model = dynamoose.model("Cat", {"id": String, "name": {"type": String, "rangeKey": true}, "age": Number});

--- a/packages/dynamoose/test/Query.js
+++ b/packages/dynamoose/test/Query.js
@@ -188,7 +188,8 @@ describe("Query", () => {
 					});
 				});
 
-				it.skip("Should send correct request on query.exec if querying main key with aliased name", async () => {
+				it("Should send correct request on query.exec using string if querying main key with aliased name", async () => {
+					queryPromiseResolver = () => ({"Items": []});
 					const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
 					new dynamoose.Table("User", [User]);
 					await callType.func(User.query("email").eq("john@john.com").exec).bind(User.query("email").eq("john@john.com"))();
@@ -204,10 +205,47 @@ describe("Query", () => {
 					});
 				});
 
-				it.skip("Should send correct request on query.exec if querying main key with range key using aliased names", async () => {
+				it("Should send correct request on query.exec using object if querying main key with aliased name", async () => {
+					queryPromiseResolver = () => ({"Items": []});
+					const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
+					new dynamoose.Table("User", [User]);
+					await callType.func(User.query({"email": {"eq": "john@john.com"}}).exec).bind(User.query({"email": {"eq": "john@john.com"}}))();
+					expect(queryParams).toEqual({
+						"TableName": "User",
+						"ExpressionAttributeNames": {
+							"#qha": "pk"
+						},
+						"ExpressionAttributeValues": {
+							":qhv": {"S": "john@john.com"}
+						},
+						"KeyConditionExpression": "#qha = :qhv"
+					});
+				});
+
+				it("Should send correct request on query.exec using string if querying main key with range key using aliased names", async () => {
+					queryPromiseResolver = () => ({"Items": []});
 					const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}, "sk": {"type": String, "alias": "name", "rangeKey": true}});
 					new dynamoose.Table("User", [User]);
 					await callType.func(User.query("email").eq("john@john.com").where("name").eq("John").exec).bind(User.query("email").eq("john@john.com").where("name").eq("John"))();
+					expect(queryParams).toEqual({
+						"TableName": "User",
+						"ExpressionAttributeNames": {
+							"#qha": "pk",
+							"#qra": "sk"
+						},
+						"ExpressionAttributeValues": {
+							":qhv": {"S": "john@john.com"},
+							":qrv": {"S": "John"}
+						},
+						"KeyConditionExpression": "#qha = :qhv AND #qra = :qrv"
+					});
+				});
+
+				it("Should send correct request on query.exec using object if querying main key with range key using aliased names", async () => {
+					queryPromiseResolver = () => ({"Items": []});
+					const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}, "sk": {"type": String, "alias": "name", "rangeKey": true}});
+					new dynamoose.Table("User", [User]);
+					await callType.func(User.query({"email": {"eq": "john@john.com"}, "name": {"eq": "John"}}).exec).bind(User.query({"email": {"eq": "john@john.com"}, "name": {"eq": "John"}}))();
 					expect(queryParams).toEqual({
 						"TableName": "User",
 						"ExpressionAttributeNames": {

--- a/packages/dynamoose/test/Scan.js
+++ b/packages/dynamoose/test/Scan.js
@@ -161,6 +161,78 @@ describe("Scan", () => {
 					expect(scanParams).toEqual({"TableName": "Cat"});
 				});
 
+				it("Should send correct request on scan.exec using string if scanning main key with aliased name", async () => {
+					scanPromiseResolver = () => ({"Items": []});
+					const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
+					new dynamoose.Table("User", [User]);
+					await callType.func(User.scan("email").eq("john@john.com").exec).bind(User.scan("email").eq("john@john.com"))();
+					expect(scanParams).toEqual({
+						"TableName": "User",
+						"ExpressionAttributeNames": {
+							"#a0": "pk"
+						},
+						"ExpressionAttributeValues": {
+							":v0": {"S": "john@john.com"}
+						},
+						"FilterExpression": "#a0 = :v0"
+					});
+				});
+
+				it("Should send correct request on scan.exec using object if scanning main key with aliased name", async () => {
+					scanPromiseResolver = () => ({"Items": []});
+					const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
+					new dynamoose.Table("User", [User]);
+					await callType.func(User.scan({"email": {"eq": "john@john.com"}}).exec).bind(User.scan({"email": {"eq": "john@john.com"}}))();
+					expect(scanParams).toEqual({
+						"TableName": "User",
+						"ExpressionAttributeNames": {
+							"#a0": "pk"
+						},
+						"ExpressionAttributeValues": {
+							":v0": {"S": "john@john.com"}
+						},
+						"FilterExpression": "#a0 = :v0"
+					});
+				});
+
+				it("Should send correct request on scan.exec using string if scanning main key with range key using aliased names", async () => {
+					scanPromiseResolver = () => ({"Items": []});
+					const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}, "sk": {"type": String, "alias": "name", "rangeKey": true}});
+					new dynamoose.Table("User", [User]);
+					await callType.func(User.scan("email").eq("john@john.com").where("name").eq("John").exec).bind(User.scan("email").eq("john@john.com").where("name").eq("John"))();
+					expect(scanParams).toEqual({
+						"TableName": "User",
+						"ExpressionAttributeNames": {
+							"#a0": "pk",
+							"#a1": "sk"
+						},
+						"ExpressionAttributeValues": {
+							":v0": {"S": "john@john.com"},
+							":v1": {"S": "John"}
+						},
+						"FilterExpression": "#a0 = :v0 AND #a1 = :v1"
+					});
+				});
+
+				it("Should send correct request on scan.exec using object if scanning main key with range key using aliased names", async () => {
+					scanPromiseResolver = () => ({"Items": []});
+					const User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}, "sk": {"type": String, "alias": "name", "rangeKey": true}});
+					new dynamoose.Table("User", [User]);
+					await callType.func(User.scan({"email": {"eq": "john@john.com"}, "name": {"eq": "John"}}).exec).bind(User.scan({"email": {"eq": "john@john.com"}, "name": {"eq": "John"}}))();
+					expect(scanParams).toEqual({
+						"TableName": "User",
+						"ExpressionAttributeNames": {
+							"#a0": "pk",
+							"#a1": "sk"
+						},
+						"ExpressionAttributeValues": {
+							":v0": {"S": "john@john.com"},
+							":v1": {"S": "John"}
+						},
+						"FilterExpression": "#a0 = :v0 AND #a1 = :v1"
+					});
+				});
+
 				it("Should send correct request on scan.exec for one object passed in", async () => {
 					scanPromiseResolver = () => ({"Items": []});
 					await callType.func(Model.scan({"name": "Charlie"}).exec).bind(Model.scan({"name": "Charlie"}))();


### PR DESCRIPTION
### Summary:
The intended effect is that you can now utilize mapped attribute when making "get" and "delete" model calls. Hopefully this can help to even further shield an application from database layer logic.

Methods affected on Model
 * get
 * delete
 * update
 * batchGet
 * batchDelete
 * query

### Code sample:

#### Model
```
User = dynamoose.model("User", {"pk": {"type": String, "alias": "email"}});
new dynamoose.Table("User", [User]);
```

#### General
```
// Old way required this
const user = await User.get({ "pk": "joe@example.com" });

// New impl allows for this as well
const user = await User.get({ "email": "joe@example.com" });
```

### GitHub linked issue:
Closes #1472 

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
