### PR TITLE
TypeMismatch field to be of type object, instead found type object.

### DIFF
--- a/packages/dynamoose/lib/Schema.ts
+++ b/packages/dynamoose/lib/Schema.ts
@@ -147,7 +147,7 @@ const attributeTypesMain: DynamoDBType[] = ((): DynamoDBType[] => {
 		new DynamoDBType({"name": "Buffer", "dynamodbType": "B", "set": true, "jsType": Buffer}),
 		booleanType,
 		new DynamoDBType({"name": "Array", "dynamodbType": "L", "jsType": {"func": Array.isArray}, "nestedType": true}),
-		new DynamoDBType({"name": "Object", "dynamodbType": "M", "jsType": {"func": (val): boolean => Boolean(val) && Object.prototype.toString.call(val) === '[object Object]'}, "nestedType": true}),
+		new DynamoDBType({"name": "Object", "dynamodbType": "M", "jsType": {"func": (val): boolean => Boolean(val) && (val.constructor === undefined || val.constructor === Object)}, "nestedType": true}),
 		numberType,
 		stringType,
 		new DynamoDBType({"name": "Date", "dynamodbType": numberType, "customType": {

--- a/packages/dynamoose/lib/Schema.ts
+++ b/packages/dynamoose/lib/Schema.ts
@@ -147,7 +147,7 @@ const attributeTypesMain: DynamoDBType[] = ((): DynamoDBType[] => {
 		new DynamoDBType({"name": "Buffer", "dynamodbType": "B", "set": true, "jsType": Buffer}),
 		booleanType,
 		new DynamoDBType({"name": "Array", "dynamodbType": "L", "jsType": {"func": Array.isArray}, "nestedType": true}),
-		new DynamoDBType({"name": "Object", "dynamodbType": "M", "jsType": {"func": (val): boolean => Boolean(val) && val.constructor === Object}, "nestedType": true}),
+		new DynamoDBType({"name": "Object", "dynamodbType": "M", "jsType": {"func": (val): boolean => Boolean(val) && Object.prototype.toString.call(val) === '[object Object]'}, "nestedType": true}),
 		numberType,
 		stringType,
 		new DynamoDBType({"name": "Date", "dynamodbType": numberType, "customType": {

--- a/packages/dynamoose/lib/utils/type_name.ts
+++ b/packages/dynamoose/lib/utils/type_name.ts
@@ -6,7 +6,12 @@ export default (value: any, typeDetailsArray: (DynamoDBTypeResult | DynamoDBSetT
 	if (value === null) {
 		str += "null";
 	} else {
-		str += typeof value;
+		// When it's a instance Class
+		if (Object.prototype.toString.call(value) === "[object Object]" && value.constructor !== undefined && value.constructor !== Object) {
+			str += value.constructor.name;
+		} else {
+			str += typeof value;
+		}
 	}
 
 	// Add constant value to type name

--- a/packages/dynamoose/test/Item.js
+++ b/packages/dynamoose/test/Item.js
@@ -513,6 +513,18 @@ describe("Item", () => {
 					}]);
 				});
 
+				it("Should save correct object with [Object null prototype] nested objects", async () => {
+					putItemFunction = () => Promise.resolve();
+					User = dynamoose.model("User", {"id": Number, "address": {"type": Object, "schema": {"data": {"type": Object, "schema": {"country": String}}, "name": String}}}, {"create": false, "waitForActive": false});
+					new dynamoose.Table("User", [User]);
+					user = new User({"id": 1, "address": {"data": Object.assign(Object.create(null), {"country": "world"}), "name": "Home"}});
+					await callType.func(user).bind(user)();
+					expect(putParams).toEqual([{
+						"Item": {"id": {"N": "1"}, "address": {"M": {"data": {"M": {"country": {"S": "world"}}}, "name": {"S": "Home"}}}},
+						"TableName": "User"
+					}]);
+				});
+
 				it("Should save correct object with object property and saveUnknown set to true", async () => {
 					putItemFunction = () => Promise.resolve();
 					User = dynamoose.model("User", new Schema({"id": Number, "address": Object}, {"saveUnknown": true}), {"create": false, "waitForActive": false});

--- a/packages/dynamoose/test/Item.js
+++ b/packages/dynamoose/test/Item.js
@@ -525,6 +525,20 @@ describe("Item", () => {
 					}]);
 				});
 
+				it("Should throw type mismatch error if passing in instance class type with object type in schema", async () => {
+					putItemFunction = () => Promise.resolve();
+					User = dynamoose.model("User", {"id": Number, "address": {"type": Object, "schema": {"data": {"type": Object, "schema": {"country": String}}, "name": String}}}, {"create": false, "waitForActive": false});
+					new dynamoose.Table("User", [User]);
+					class Address {
+						constructor (country) {
+							this.country = country;
+						}
+					}
+					user = new User({"id": 1, "address": {"data": new Address("world"), "name": "Home"}});
+
+					return expect(callType.func(user).bind(user)()).rejects.toEqual(new CustomError.TypeMismatch("Expected address.data to be of type object, instead found type Address."));
+				});
+
 				it("Should save correct object with object property and saveUnknown set to true", async () => {
 					putItemFunction = () => Promise.resolve();
 					User = dynamoose.model("User", new Schema({"id": Number, "address": Object}, {"saveUnknown": true}), {"create": false, "waitForActive": false});


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:

Currently, some libs use objects with null prototype to avoid function injection. The issue is explained here: https://github.com/graphql/graphql-js/issues/484#issuecomment-250344120.

Technically there are objects with a null prototype and they need to be recognized by Dynamoose schema. Without that, we'll have to deep copy those objects recovering the prototype (or just the `constructor = Object`).

It's a bug because those types are object and Dynamoose getting confused about that and raise a confused message:
> TypeMismatch: Expected {the name of the field} to be of type object, instead found type object.

I'm offering a safe and quick solution to recognize those objects and allow them to be stored on DynamoDB as regular objects.


<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```ts
User = dynamoose.model("User", {
  "address": {
    "type": Object,
    "schema": {"country": String}
  }
});
```

#### General
```ts
user = new User({
  "address": Object.assign(Object.create(null), {"country": "world"})
});
// It will raise the weird Error: 
// TypeMismatch: Expected address to be of type object, instead found type object.

```

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [x] Test added to report bug 
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
