### PR TITLE
Version 2.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ---
 
+## Version 2.8.8
+
+This release includes a few bug fixes that were back-ported from v3.
+
+Please comment or [contact me](https://charlie.fish/contact) if you have any questions about this release.
+
+### Bug Fixes
+
+- Fix TypeScript return types to allow for chainable methods for `Query` & `Scan`
+- Add support for `null` prototype objects on attribute type Object
+
+---
+
 ## Version 2.8.7
 
 Version 3.0.0 of Dynamoose has been released. This is the corresponding v2 release. v2 will continue to receive bug fixes and security updates as needed for time being. However, we recommend that you upgrade to v3 as soon as possible, as v2 will not be maintained forever.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Below you will find the current branch strategy for the project. Work taking pla
 | --- | --- | --- | --- |
 | [`main`](https://github.com/dynamoose/dynamoose/tree/main) | 3.x.x | beta | - [Documentation](https://dynamoose.pages.dev/)<br>- [Pending Changelog](https://github.com/dynamoose/dynamoose/blob/main/PENDING_CHANGELOG.md) |
 | [`v2`](https://github.com/dynamoose/dynamoose/tree/v2) | 2.8.x |   | - [Documentation](https://v2.dynamoose.pages.dev/) |
-| [`v2.8.7` (tag)](https://github.com/dynamoose/dynamoose/tree/v2.8.7) | 2.8.7 | latest | - [Documentation](https://dynamoosejs.com)
+| [`v2.8.8` (tag)](https://github.com/dynamoose/dynamoose/tree/v2.8.8) | 2.8.8 | latest | - [Documentation](https://dynamoosejs.com)
+
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamoose",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamoose",
-      "version": "2.8.7",
+      "version": "2.8.8",
       "funding": [
         {
           "type": "github-sponsors",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "Dynamoose is a modeling tool for Amazon's DynamoDB (inspired by Mongoose)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Version 2.8.8

This release includes a few bug fixes that were back-ported from v3.

Please comment or [contact me](https://charlie.fish/contact) if you have any questions about this release.

### Bug Fixes

- Fix TypeScript return types to allow for chainable methods for `Query` & `Scan`
- Add support for `null` prototype objects on attribute type Object