### PR TITLE
Adjust the return of save/create to conform to schema

### DIFF
--- a/packages/dynamoose/lib/Item.ts
+++ b/packages/dynamoose/lib/Item.ts
@@ -439,7 +439,12 @@ export class Item extends InternalPropertiesClass<ItemInternalProperties> {
 
 		const localSettings: ItemSaveSettings = settings;
 		const paramsPromise = this.toDynamo({"defaults": true, "validate": true, "required": true, "enum": true, "forceDefault": true, "combine": true, "saveUnknown": true, "customTypesDynamo": true, "updateTimestamps": true, "modifiers": ["set"], "mapAttributes": true}).then(async (item) => {
-			savedItem = item;
+			const conformToSchemaSettings : ItemObjectFromSchemaSettings = {"combine": true, "customTypesDynamo": true, "saveUnknown": true, "type": "fromDynamo", "modifiers": ["get"], "mapAttributes": true};
+			savedItem = await new (this.getInternalProperties(internalProperties).model).Item(item as any).conformToSchema(conformToSchemaSettings);
+			Object.keys(savedItem).forEach((key) => this[key] = savedItem[key]);
+			savedItem.getInternalProperties(internalProperties).storedInDynamo = true;
+			this.getInternalProperties(internalProperties).storedInDynamo = true;
+
 			let putItemObj: DynamoDB.PutItemInput = {
 				"Item": item,
 				"TableName": table.getInternalProperties(internalProperties).name
@@ -477,26 +482,12 @@ export class Item extends InternalPropertiesClass<ItemInternalProperties> {
 			return ddb(table.getInternalProperties(internalProperties).instance, "putItem", putItemObj);
 		});
 
+
 		if (callback) {
 			const localCallback: CallbackType<Item, any> = callback as CallbackType<Item, any>;
-			promise.then(() => {
-				this.getInternalProperties(internalProperties).storedInDynamo = true;
-
-				const returnItem = new (this.getInternalProperties(internalProperties).model).Item(savedItem as any);
-				returnItem.getInternalProperties(internalProperties).storedInDynamo = true;
-
-				localCallback(null, returnItem);
-			}).catch((error) => callback(error));
+			promise.then(() => localCallback(null, savedItem), (error) => callback(error));
 		} else {
-			return (async (): Promise<Item> => {
-				await promise;
-				this.getInternalProperties(internalProperties).storedInDynamo = true;
-
-				const returnItem = new (this.getInternalProperties(internalProperties).model).Item(savedItem as any);
-				returnItem.getInternalProperties(internalProperties).storedInDynamo = true;
-
-				return returnItem;
-			})();
+			return promise.then(() => savedItem);
 		}
 	}
 

--- a/packages/dynamoose/test/Item.js
+++ b/packages/dynamoose/test/Item.js
@@ -121,9 +121,9 @@ describe("Item", () => {
 					return putItemFunction();
 				}
 			});
-			User = dynamoose.model("User", {"id": Number, "name": String});
+			User = dynamoose.model("User", {"id": Number, "name": String, "birthday": Date});
 			new dynamoose.Table("User", [User]);
-			user = new User({"id": 1, "name": "Charlie"});
+			user = new User({"id": 1, "name": "Charlie", "birthday": new Date(10000)});
 		});
 		afterEach(() => {
 			dynamoose.Table.defaults.set({});
@@ -148,7 +148,7 @@ describe("Item", () => {
 					putItemFunction = () => Promise.resolve();
 					await callType.func(user).bind(user)();
 					expect(putParams).toEqual([{
-						"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}},
+						"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "birthday": {"N": `${new Date(10000).getTime()}`}},
 						"TableName": "User"
 					}]);
 				});
@@ -165,7 +165,7 @@ describe("Item", () => {
 					expect(resultA).toEqual(user);
 					expect(resultB).toEqual(robot);
 					expect(putParams).toEqual([{
-						"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}},
+						"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "birthday": {"N": `${new Date(10000).getTime()}`}},
 						"TableName": "User"
 					}, {
 						"Item": {"id": {"N": "2"}, "built": {"N": `${date}`}},
@@ -209,7 +209,8 @@ describe("Item", () => {
 					expect(result).toEqual({
 						"Item": {
 							"id": {"N": "1"},
-							"name": {"S": "Charlie"}
+							"name": {"S": "Charlie"},
+							"birthday": {"N": `${new Date(10000).getTime()}`}
 						},
 						"TableName": "User"
 					});
@@ -1707,7 +1708,7 @@ describe("Item", () => {
 						error = e;
 					}
 					expect(putParams).toEqual([{
-						"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}},
+						"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}, "birthday": {"N": `${new Date(10000).getTime()}`}},
 						"TableName": "User"
 					}]);
 					expect(result).not.toBeDefined();

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -1728,9 +1728,9 @@ describe("Model", () => {
 					// Check original timestamps
 					expect(result.id).toEqual(1);
 					expect(result.name).toEqual("Charlie");
-					expect(typeof result.createdAt).toEqual("number");
+					expect(result.createdAt.constructor).toEqual(Date);
 					expect(result.createdAt).toBeWithinRange(date1 - 10, date1 + 10);
-					expect(typeof result.updatedAt).toEqual("number");
+					expect(result.updatedAt.constructor).toEqual(Date);
 					expect(result.updatedAt).toBeWithinRange(date1 - 10, date1 + 10);
 
 					await new Promise((resolve) => setTimeout(resolve, 20));
@@ -1740,15 +1740,16 @@ describe("Model", () => {
 					// Mutate document and re-save
 					result.name = "Charlie 2";
 					const result2 = await result.save();
+					const date3 = Date.now();
 
 					expect(result.toJSON()).toEqual(result2.toJSON());
 					[result, result2].forEach((r) => {
 						expect(r.id).toEqual(1);
 						expect(r.name).toEqual("Charlie 2");
-						expect(typeof r.createdAt).toEqual("number");
-						expect(r.createdAt).toBeWithinRange(date1 - 10, date1 + 10);
-						expect(typeof r.updatedAt).toEqual("number");
-						expect(r.updatedAt).toBeWithinRange(date2 - 10, date2 + 10);
+						expect(r.createdAt.constructor).toEqual(Date);
+						expect(r.createdAt.getTime()).toBeWithinRange(date1, date3);
+						expect(r.updatedAt.constructor).toEqual(Date);
+						expect(r.updatedAt.getTime()).toBeWithinRange(date2, date3);
 					});
 				});
 			});


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:


This PR adjusts the return of `save` or `create` when the return is `item`. Before my PR the return was exactly what is being sending to the DynamoDB (the result of `toDynamo`). My PR performs a `conformToSchema` on that return and copies the result to `this`'s attributes.

<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```ts
new dynamoose.Schema({ id: { type: String, hashKey: true }, birthday: Date })
```

#### General
```ts
const birthday = new Date();
const user = await User.create({ birthday });

user.birthday === birthday; // before that PR user.birthday was number
```


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
[#1479](https://github.com/dynamoose/dynamoose/issues/1479)


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:




### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [x] Test added to report bug (GitHub issue [#1479](https://github.com/dynamoose/dynamoose/issues/1479))
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [x] 🚨 YES 🚨
- [ ] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
