### PR TITLE
Do not calculate the schemaCorrectnessScores for models and tables with single schema

### DIFF
--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -240,10 +240,16 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 			},
 			// This function returns the best matched schema for the given object input
 			"schemaForObject": (object: ObjectType): Schema => {
+				const schemas = this.getInternalProperties(internalProperties).schemas;
+
+				if (schemas.length === 1) {
+					return schemas[0];
+				}
+
 				const schemaCorrectnessScores = this.getInternalProperties(internalProperties).schemaCorrectnessScores(object);
 				const highestSchemaCorrectnessScoreIndex: number = schemaCorrectnessScores.indexOf(Math.max(...schemaCorrectnessScores));
 
-				return this.getInternalProperties(internalProperties).schemas[highestSchemaCorrectnessScoreIndex];
+				return schemas[highestSchemaCorrectnessScoreIndex];
 			},
 			// This function returns the DynamoDB property name for a given attribute (alias or property name). For example if you have a `pk` with an alias of `userID` and pass in `userID` it will return `pk`. If you pass in `pk` it will return `pk`.
 			"dynamoPropertyForAttribute": async (attribute: string): Promise<string> => {

--- a/packages/dynamoose/lib/Table/index.ts
+++ b/packages/dynamoose/lib/Table/index.ts
@@ -182,6 +182,11 @@ export class Table extends InternalPropertiesClass<TableInternalProperties> {
 			// This function returns the best matched model for the given object input
 			"modelForObject": async (object: ObjectType): Promise<Model<ItemCarrier>> => {
 				const models = this.getInternalProperties(internalProperties).models;
+
+				if (models.length === 1) {
+					return models[0];
+				}
+
 				const modelSchemaCorrectnessScores = models.map((model) => Math.max(...model.Model.getInternalProperties(internalProperties).schemaCorrectnessScores(object)));
 				const highestModelSchemaCorrectnessScore = Math.max(...modelSchemaCorrectnessScores);
 				const bestModelIndex = modelSchemaCorrectnessScores.indexOf(highestModelSchemaCorrectnessScore);


### PR DESCRIPTION
### Summary:
In order to prevent extra calculations on models and tables with just a single schema in `Model.schemaForObject` and `Table.modelForObject` methods we just return the first schema/model. As the more attributes the schema has, the more calculations need to be made to find the `schemaCorrectnessScores`.

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
