### PR TITLE
Common table instance for models with same tableName

### DIFF
--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -371,7 +371,7 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 		_ModelStore(this);
 
 		// This code attaches `this` model to an existing table instance created by other model with the same tableName.
-		const modelsOfTable = ModelStore.forTableName(this.getInternalProperties(internalProperties).tableName);
+		const modelsOfTable = _ModelStore.forTableName(this.getInternalProperties(internalProperties).tableName);
 		const otherModelWithTable = modelsOfTable.find((model) => model !== this && model.table());
 		const table = otherModelWithTable?.table();
 

--- a/packages/dynamoose/lib/ModelStore.ts
+++ b/packages/dynamoose/lib/ModelStore.ts
@@ -25,7 +25,7 @@ returnObject.clear = (): void => {
  * @returns Array of Models.
  */
 returnObject.forTableName = (tableName: string): Model<Item>[] | undefined => {
-	const modelsInTable = Object.values(models).filter((model) => model.getInternalProperties(internalProperties).table().name === tableName);
+	const modelsInTable = Object.values(models).filter((model) => model.getInternalProperties(internalProperties).tableName === tableName);
 
 	return modelsInTable.length === 0 ? undefined : modelsInTable;
 };

--- a/packages/dynamoose/lib/Table/index.ts
+++ b/packages/dynamoose/lib/Table/index.ts
@@ -161,7 +161,8 @@ export class Table extends InternalPropertiesClass<TableInternalProperties> {
 
 				model.Model.setInternalProperties(internalProperties, {
 					...model.Model.getInternalProperties(internalProperties),
-					"_table": this
+					"_table": this,
+					"tableName": name
 				});
 				return model;
 			}),

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -215,6 +215,24 @@ describe("Model", () => {
 		});
 	});
 
+	it("Should create only one table instance for two or more models with same table name", async () => {
+		const customTableName = "custom-table-name";
+		const Cat = dynamoose.model("Cat", {"id": String, "type": {"type": String, "default": "cat"}}, {"tableName": customTableName});
+		const Dog = dynamoose.model("Dog", {"id": String, "type": {"type": String, "default": "dog"}}, {"tableName": customTableName});
+		expect(Cat.table()).toStrictEqual(Dog.table());
+		expect(Cat.table().getInternalProperties(internalProperties).models).toEqual([Cat, Dog]);
+	});
+
+	it("Should attach subsequent models with same table name to existing table instance", async () => {
+		const customTableName = "custom-table-name";
+		const Cat = dynamoose.model("Cat", {"id": String, "type": {"type": String, "default": "cat"}}, {"tableName": customTableName});
+		const catTable = Cat.table();
+		expect(catTable.getInternalProperties(internalProperties).models).toEqual([Cat]);
+
+		const Dog = dynamoose.model("Dog", {"id": String, "type": {"type": String, "default": "dog"}}, {"tableName": customTableName});
+		expect(catTable.getInternalProperties(internalProperties).models).toEqual([Cat, Dog]);
+	});
+
 	describe("model.get()", () => {
 		let User, getItemParams, getItemFunction;
 		beforeEach(() => {

--- a/packages/dynamoose/test/Table.js
+++ b/packages/dynamoose/test/Table.js
@@ -2137,4 +2137,16 @@ describe("Table", () => {
 			expect(table.getInternalProperties(internalProperties).getRangeKey()).toEqual("age");
 		});
 	});
+
+	describe("models", () => {
+		it("Should append new models with same table name provided", async () => {
+			const tableName = "pets";
+			const Cat = dynamoose.model("Cat", {"id": String, "name": String});
+			const table = new dynamoose.Table(tableName, [Cat]);
+			expect(table.getInternalProperties(internalProperties).models).toEqual([Cat]);
+
+			const Dog = dynamoose.model("Dog", {"id": String, "name": String}, {"tableName": tableName});
+			expect(table.getInternalProperties(internalProperties).models).toEqual([Cat, Dog]);
+		});
+	});
 });


### PR DESCRIPTION
Different models with same tableName now shares same table instance

### Summary:
The problem is from my previous pr https://github.com/dynamoose/dynamoose/pull/1515 that adds tableName option to a Model constructor. Creating two models with same tableName led to creating of two table instances with same name but different models inside internal prop `models`.

Now creating a second and subsequent models with same tableName will lead to appending them to an existing table instance created by the first model created.

### Code sample:
#### Model
```ts
const customTableName = "pets";

const Cat = dynamoose.model("Cat", {"id": String, "type": {"type": String, "default": "cat"}}, {"tableName": customTableName});
const catTable = Cat.table();
// Cat.table().getInternalProperties(internalProperties).models == [Cat]

const Dog = dynamoose.model("Dog", {"id": String, "type": {"type": String, "default": "dog"}}, {"tableName": customTableName});
// Cat.table().getInternalProperties(internalProperties).models ===  Dog.table().getInternalProperties(internalProperties).models == [Cat, Dog] 
```
### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement

### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above