### PR TITLE
fix:typoError - repetition of alias property

### DIFF
--- a/docs/docs_src/guide/Schema.md
+++ b/docs/docs_src/guide/Schema.md
@@ -197,10 +197,6 @@ dyno_jsdoc_dist/Schema.d.ts|AttributeDefinition.map
 
 This property is the same as [`map`](#map-string--string) and used as an alias for that property.
 
-### aliases: string | [string]
-
-This property is the same as [`map`](#map-string--string) and used as an alias for that property.
-
 ### defaultMap: string
 
 dyno_jsdoc_dist/Schema.d.ts|AttributeDefinition.defaultMap


### PR DESCRIPTION
### Summary:
On Dynamoose documentation, the Schema page inside the Guide the following [the alias section](https://dynamoosejs.com/guide/Schema#alias-string--string) repeats multi times.
So I just simply edit the docs/docs_src/guide/Schema.md to fix the repetitions.

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [x] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [ ] No
- [x] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
