### PR TITLE
Fixed the duplication of alias property inside guide/schema (Documentation)

### DIFF
--- a/docs/docs_src/guide/Schema.md
+++ b/docs/docs_src/guide/Schema.md
@@ -193,10 +193,6 @@ dyno_jsdoc_dist/Schema.d.ts|AttributeDefinition.rangeKey
 
 dyno_jsdoc_dist/Schema.d.ts|AttributeDefinition.map
 
-### alias: string | [string]
-
-This property is the same as [`map`](#map-string--string) and used as an alias for that property.
-
 ### aliases: string | [string]
 
 This property is the same as [`map`](#map-string--string) and used as an alias for that property.


### PR DESCRIPTION
I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

@fishcharlie Can please review this PR and fix this typo mistake.