### PR TITLE
Table query

### DIFF
--- a/docs/docs_src/guide/Table.md
+++ b/docs/docs_src/guide/Table.md
@@ -57,3 +57,7 @@ dyno_jsdoc_dist/Table/index.js|table.create
 ## table.initialize([callback])
 
 dyno_jsdoc_dist/Table/index.js|table.initialize
+
+## table.query([callback])
+
+dyno_jsdoc_dist/Table/index.js|table.query

--- a/packages/dynamoose/lib/Condition.ts
+++ b/packages/dynamoose/lib/Condition.ts
@@ -141,7 +141,7 @@ export class Condition extends InternalPropertiesClass<ConditionInternalProperti
 			"requestObject": async (models: Model<Item>[], settings: ConditionRequestObjectSettings = {"conditionString": "ConditionExpression", "conditionStringType": "string"}): Promise<ConditionRequestObjectResult> => {
 				const toDynamo = async (key: string, value: ObjectType): Promise<DynamoDB.AttributeValue> => {
 					const object = {[key]: value};
-					const modelForObject = await models[0].table().getInternalProperties(internalProperties).modelForObject(object);
+					const modelForObject = await models[0].getInternalProperties(internalProperties).table().getInternalProperties(internalProperties).modelForObject(object);
 					const newObj = await Item.objectFromSchema(object, modelForObject.Model, {"type": "toDynamo", "modifiers": ["set"], "typeCheck": false, "mapAttributes": true});
 					const newObjKeys = Object.keys(newObj);
 					// TODO: not quite sure how to unit test the error below. Need to figure this out. Maybe by mocking `Item.objectFromSchema`??? We don't currently have a system in place to do that easily tho.

--- a/packages/dynamoose/lib/Condition.ts
+++ b/packages/dynamoose/lib/Condition.ts
@@ -114,7 +114,7 @@ type ConditionObject = {
 } | typeof OR;
 
 interface ConditionInternalProperties {
-	requestObject: (model: Model<Item>, settings?: ConditionRequestObjectSettings) => Promise<ConditionRequestObjectResult>;
+	requestObject: (models: Model<Item>[], settings?: ConditionRequestObjectSettings) => Promise<ConditionRequestObjectResult>;
 	settings?: {
 		conditions?: ConditionObject[];
 		pending?: {
@@ -138,9 +138,11 @@ export class Condition extends InternalPropertiesClass<ConditionInternalProperti
 		super();
 
 		this.setInternalProperties(internalProperties, {
-			"requestObject": async (model: Model<Item>, settings: ConditionRequestObjectSettings = {"conditionString": "ConditionExpression", "conditionStringType": "string"}): Promise<ConditionRequestObjectResult> => {
+			"requestObject": async (models: Model<Item>[], settings: ConditionRequestObjectSettings = {"conditionString": "ConditionExpression", "conditionStringType": "string"}): Promise<ConditionRequestObjectResult> => {
 				const toDynamo = async (key: string, value: ObjectType): Promise<DynamoDB.AttributeValue> => {
-					const newObj = await Item.objectFromSchema({[key]: value}, model, {"type": "toDynamo", "modifiers": ["set"], "typeCheck": false, "mapAttributes": true});
+					const object = {[key]: value};
+					const modelForObject = await models[0].table().getInternalProperties(internalProperties).modelForObject(object);
+					const newObj = await Item.objectFromSchema(object, modelForObject.Model, {"type": "toDynamo", "modifiers": ["set"], "typeCheck": false, "mapAttributes": true});
 					const newObjKeys = Object.keys(newObj);
 					// TODO: not quite sure how to unit test the error below. Need to figure this out. Maybe by mocking `Item.objectFromSchema`??? We don't currently have a system in place to do that easily tho.
 					/* istanbul ignore next */
@@ -182,7 +184,7 @@ export class Condition extends InternalPropertiesClass<ConditionInternalProperti
 							object = {...object, ...returnObject};
 						} else if (entry !== OR) {
 							const keyConditionObj = Object.entries(entry)[0];
-							const key = await model.getInternalProperties(internalProperties).dynamoPropertyForAttribute(keyConditionObj[0]);
+							const key = await models[0].getInternalProperties(internalProperties).dynamoPropertyForAttribute(keyConditionObj[0]);
 							const condition = keyConditionObj[1];
 							const {value} = condition;
 							const keys = {"name": `#a${index}`, "value": `:v${index}`};

--- a/packages/dynamoose/lib/Item.ts
+++ b/packages/dynamoose/lib/Item.ts
@@ -448,7 +448,7 @@ export class Item extends InternalPropertiesClass<ItemInternalProperties> {
 			if (localSettings.condition) {
 				putItemObj = {
 					...putItemObj,
-					...await localSettings.condition.getInternalProperties(internalProperties).requestObject(this.getInternalProperties(internalProperties).model)
+					...await localSettings.condition.getInternalProperties(internalProperties).requestObject([this.getInternalProperties(internalProperties).model])
 				};
 			}
 

--- a/packages/dynamoose/lib/ItemRetriever.ts
+++ b/packages/dynamoose/lib/ItemRetriever.ts
@@ -171,7 +171,7 @@ Object.getOwnPropertyNames(Condition.prototype).forEach((key: string) => {
 
 ItemRetriever.prototype.getRequest = async function (this: ItemRetriever): Promise<any> {
 	const {models} = this.getInternalProperties(internalProperties).internalSettings;
-	// TODO: Same.
+	// TODO: Check that all the models shares the same table
 	const table = models[0].getInternalProperties(internalProperties).table();
 
 	const object: any = {

--- a/packages/dynamoose/lib/ItemRetriever.ts
+++ b/packages/dynamoose/lib/ItemRetriever.ts
@@ -4,7 +4,7 @@ import utils from "./utils";
 import {Condition, ConditionInitializer, BasicOperators} from "./Condition";
 import {Model} from "./Model";
 import {Item} from "./Item";
-import { CallbackType, ObjectType, ItemArray, SortOrder, ModelType } from './General'
+import {CallbackType, ObjectType, ItemArray, SortOrder, ModelType} from "./General";
 import {PopulateItems} from "./Populate";
 import Internal from "./Internal";
 import {InternalPropertiesClass} from "./InternalPropertiesClass";
@@ -68,9 +68,9 @@ abstract class ItemRetriever extends InternalPropertiesClass<ItemRetrieverIntern
 				};
 			}
 
-			const buildItemFromModel = (model: ModelType<Item>, item: Model<Item>) => (
+			const buildItemFromModel = (model: ModelType<Item>, item: Model<Item>) =>
 				new model.Item(item, {"type": "fromDynamo"}).conformToSchema({"customTypesDynamo": true, "checkExpiredItem": true, "saveUnknown": true, "modifiers": ["get"], "type": "fromDynamo", "mapAttributes": true})
-			);
+			;
 
 			const array: any = (await Promise.all(result.Items.map(async (item: Model<Item>) => {
 				const suitableModelForBuildItem = await table.getInternalProperties(internalProperties).modelForObject(item);

--- a/packages/dynamoose/lib/Schema.ts
+++ b/packages/dynamoose/lib/Schema.ts
@@ -2,7 +2,7 @@ import CustomError from "./Error";
 import utils from "./utils";
 import Internal from "./Internal";
 import {Item, ItemObjectFromSchemaSettings} from "./Item";
-import {Model, ModelIndexes} from "./Model";
+import {Model, ModelIndexes, schemaCorrectnessScoresSettings} from "./Model";
 import * as DynamoDB from "@aws-sdk/client-dynamodb";
 import {ModelType, ObjectType} from "./General";
 import {InternalPropertiesClass} from "./InternalPropertiesClass";
@@ -1423,7 +1423,7 @@ export class Schema extends InternalPropertiesClass<SchemaInternalProperties> {
 			return func(attributeValue);
 		}
 	}
-	getTypePaths (object: ObjectType, settings: { type: "toDynamo" | "fromDynamo"; previousKey?: string; includeAllProperties?: boolean } = {"type": "toDynamo"}): ObjectType {
+	getTypePaths (object: ObjectType, settings: { type: "toDynamo" | "fromDynamo"; previousKey?: string; includeAllProperties?: boolean } & schemaCorrectnessScoresSettings = {"type": "toDynamo"}): ObjectType {
 		return Object.entries(object).reduce((result, entry) => {
 			const [key, value] = entry;
 			const fullKey = [settings.previousKey, key].filter((a) => Boolean(a)).join(".");
@@ -1478,7 +1478,8 @@ export class Schema extends InternalPropertiesClass<SchemaInternalProperties> {
 					result[fullKey] = matchedTypeDetailsIndex;
 				}
 			} else if (settings.includeAllProperties) {
-				const matchCorrectness: number = typeCheckResult.isValidType ? 1 : 0;
+				const defaultValue = this.getAttributeSettingValue("default", key) || this.getAttributeSettingValue("default", fullKey);
+				const matchCorrectness = typeCheckResult.isValidType ? settings.considerDefaults && value !== undefined && defaultValue !== undefined && value === defaultValue ? 2 : 1 : 0;
 				result[fullKey] = {
 					"index": 0,
 					matchCorrectness,

--- a/packages/dynamoose/lib/Table/index.ts
+++ b/packages/dynamoose/lib/Table/index.ts
@@ -4,7 +4,7 @@ import {CallbackType, DeepPartial, ModelType, ObjectType} from "../General";
 import Internal from "../Internal";
 import {Query} from "../ItemRetriever";
 const {internalProperties} = Internal.General;
-import { Model, schemaCorrectnessScoresSettings } from '../Model'
+import {Model, schemaCorrectnessScoresSettings} from "../Model";
 import {custom as customDefaults, original as originalDefaults} from "./defaults";
 import utils from "../utils";
 import * as DynamoDB from "@aws-sdk/client-dynamodb";

--- a/packages/dynamoose/lib/Table/index.ts
+++ b/packages/dynamoose/lib/Table/index.ts
@@ -207,10 +207,10 @@ export class Table extends InternalPropertiesClass<TableInternalProperties> {
 					"arrayItemsMerger": utils.merge_objects.schemaAttributesMerger
 				})(...createTableAttributeParams);
 			},
-			"getHashKey": () => {
+			"getHashKey": (): string => {
 				return this.getInternalProperties(internalProperties).models[0].Model.getInternalProperties(internalProperties).getHashKey();
 			},
-			"getRangeKey": () => {
+			"getRangeKey": (): string | void => {
 				return this.getInternalProperties(internalProperties).models[0].Model.getInternalProperties(internalProperties).getRangeKey();
 			},
 			"runSetupFlow": async (): Promise<void> => {
@@ -356,7 +356,7 @@ export class Table extends InternalPropertiesClass<TableInternalProperties> {
 	 * ```
 	 * @readonly
 	 */
-	get rangeKey () {
+	get rangeKey (): string | void {
 		return this.getInternalProperties(internalProperties).getRangeKey();
 	}
 	/**

--- a/packages/dynamoose/test/Condition.js
+++ b/packages/dynamoose/test/Condition.js
@@ -251,21 +251,25 @@ describe("Condition", () => {
 
 		tests.forEach((test) => {
 			it(`Should ${test.error ? "throw" : "return"} ${JSON.stringify(test.error || test.output)} for ${JSON.stringify(test.input)}`, async () => {
-				const model = {
-					"getInternalProperties": () => ({
+				function model () {
+					this.Model = this;
+					this.getInternalProperties = () => ({
 						"table": () => ({
 							"getInternalProperties": () => ({
-								"instance": Instance.default
+								"instance": Instance.default,
+								"modelForObject": () => this
 							})
 						}),
 						"schemaForObject": () => new dynamoose.Schema({"id": String}),
 						"dynamoPropertyForAttribute": (key) => key
-					})
-				};
+					});
+
+					return this;
+				}
 				if (test.error) {
-					return expect(() => test.input().requestObject(model, test.settings)).toThrow(test.error);
+					return expect(() => test.input().requestObject([model()], test.settings)).toThrow(test.error);
 				} else {
-					return expect(await test.input().getInternalProperties(internalProperties).requestObject(model, test.settings)).toEqual(test.output);
+					return expect(await test.input().getInternalProperties(internalProperties).requestObject([model()], test.settings)).toEqual(test.output);
 				}
 			});
 		});

--- a/packages/dynamoose/test/Query.js
+++ b/packages/dynamoose/test/Query.js
@@ -5,6 +5,11 @@ const {internalProperties} = require("../dist/Internal").default.General;
 const CustomError = require("../dist/Error").default;
 
 describe("Query", () => {
+	// beforeAll(async () => {
+	// 	const logger = await dynamoose.logger();
+	// 	logger.providers.set(console);
+	// });
+
 	beforeEach(() => {
 		dynamoose.Table.defaults.set({"create": false, "waitForActive": false});
 	});
@@ -14,14 +19,17 @@ describe("Query", () => {
 
 	let queryPromiseResolver, queryParams;
 	beforeEach(() => {
+		// console.log("fired beforeEach");
 		dynamoose.aws.ddb.set({
 			"query": (request) => {
 				queryParams = request;
+				// console.log("queryPromiseResolver", queryPromiseResolver);
 				return queryPromiseResolver();
 			}
 		});
 	});
 	afterEach(() => {
+		// console.log("fired afterEach");
 		dynamoose.aws.ddb.revert();
 		queryPromiseResolver = null;
 		queryParams = null;
@@ -67,9 +75,11 @@ describe("Query", () => {
 			expect(Model.query().exec).toBeInstanceOf(Function);
 		});
 
-		it("Should return a promise", () => {
+		it("Should return a promise", async () => {
 			queryPromiseResolver = () => ({"Items": []});
-			expect(Model.query("name").eq("Charlie").exec()).toBeInstanceOf(Promise);
+			const promise = Model.query("name").eq("Charlie").exec();
+			expect(promise).toBeInstanceOf(Promise);
+			await promise;
 		});
 
 		const functionCallTypes = [

--- a/packages/dynamoose/test/Query.js
+++ b/packages/dynamoose/test/Query.js
@@ -5,11 +5,6 @@ const {internalProperties} = require("../dist/Internal").default.General;
 const CustomError = require("../dist/Error").default;
 
 describe("Query", () => {
-	// beforeAll(async () => {
-	// 	const logger = await dynamoose.logger();
-	// 	logger.providers.set(console);
-	// });
-
 	beforeEach(() => {
 		dynamoose.Table.defaults.set({"create": false, "waitForActive": false});
 	});
@@ -19,17 +14,14 @@ describe("Query", () => {
 
 	let queryPromiseResolver, queryParams;
 	beforeEach(() => {
-		// console.log("fired beforeEach");
 		dynamoose.aws.ddb.set({
 			"query": (request) => {
 				queryParams = request;
-				// console.log("queryPromiseResolver", queryPromiseResolver);
 				return queryPromiseResolver();
 			}
 		});
 	});
 	afterEach(() => {
-		// console.log("fired afterEach");
 		dynamoose.aws.ddb.revert();
 		queryPromiseResolver = null;
 		queryParams = null;

--- a/packages/dynamoose/test/Table.js
+++ b/packages/dynamoose/test/Table.js
@@ -2082,6 +2082,15 @@ describe("Table", () => {
 			expect(await table.getInternalProperties(internalProperties).modelForObject({"id": "1", "data": "John", "item": "Smith"})).toEqual(model);
 		});
 
+		it("Should return correct model using model attributes' defaults", async () => {
+			const catModel = dynamoose.model("Cat", {"id": String, "name": String, "type": {"type": String, "default": "cat"}});
+			const dogModel = dynamoose.model("Dog", {"id": String, "name": String, "type": {"type": String, "default": "dog"}});
+			const table = new dynamoose.Table("Pets", [catModel, dogModel]);
+
+			expect(await table.getInternalProperties(internalProperties).modelForObject({"id": "1", "type": "cat"})).toEqual(catModel);
+			expect(await table.getInternalProperties(internalProperties).modelForObject({"id": "1", "type": "dog"}, {"considerDefaults": true})).toEqual(dogModel);
+		});
+
 		it("Should return the first model if it is the only one", async () => {
 			const model = dynamoose.model("User", {"id": String, "name": String});
 			const table = new dynamoose.Table("Table", [model]);


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
Adds the ability to table.query() respecting models correctly. Useful for utilising the single table approach when you want to get multiple items of different models within single request.
⚠️ Preferably to be reviewed after https://github.com/dynamoose/dynamoose/pull/1517 (depends on https://github.com/dynamoose/dynamoose/pull/1517) as the current one is based on it.

<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### General
Let's assume we have two models Team and TeamMember within single table:
```ts
const Team = dynamoose.model("Team", {
  "pk": {
    "type": String,
    "index": {
      "hashKey": true,
      "index": {
        "name": "primary",
        "type": "global"
      }
    },
    "map": "id"
  },
  "sk": {
    "type": String,
    "rangeKey": true
  },
  "name": String,
  "type": {"type": String, "default": "team"}
});
const TeamMember = dynamoose.model("TeamMember", {
  "pk": {
    "type": String,
    "index": {
      "hashKey": true,
      "index": {
        "name": "primary",
        "type": "global"
      }
    },
    "map": "teamId"
  },
  "sk": {
    "type": String,
    "rangeKey": true,
    "map": "id"
  },
  "name": String,
  "type": {"type": String, "default": "member"}
});
const table = new dynamoose.Table("teams", [Team, TeamMember]);
```
and some instances of each type:
```ts
const team1 = new Team({"id": "team_1", "name": "Team 1"});
const member1 = new TeamMember({"teamId": "team_1", "id": "member_1", "name": "Team member 1"});
```
now we can query the table for any global index (i.e. primary key) and get relevant items with correct models mapping:
```ts
await table.query({"pk": "team_1"}).exec()
// will return the following:
[
  Team {
    id: 'team_1',
    sk: '',
    name: 'Team 1',
    type: 'team'
  },
  TeamMember {
    teamId: 'team_1',
    id: 'member_1',
    name: 'Team member 1',
    type: 'member'
  },
]
```
The models of each item are identified correctly and all the attributes are mapped as we expect in our schemas.

The magic is in respecting attributes' default values which add +2 score weight and in improved Model.schemaCorrectnessScores method by adding up the scores to determine the most suitable model even if the models' schemas are same except default values.

### Type (select 1):
- [ ] Bug fix
- [x] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
