### PR TITLE
Batch get/consistent reads

### DIFF
--- a/docs/docs_src/guide/Model.md
+++ b/docs/docs_src/guide/Model.md
@@ -126,6 +126,7 @@ You can also pass in an object for the optional `settings` parameter that is an 
 |------|-------------|------|---------|
 | return | What the function should return. Can be `items`, or `request`. In the event this is set to `request` the request Dynamoose will make to DynamoDB will be returned, and no request to DynamoDB will be made. If this is `request`, the function will not be async anymore. | String | `items` |
 | attributes | What item attributes should be retrieved & returned. This will use the underlying `AttributesToGet` DynamoDB option to ensure only the attributes you request will be sent over the wire. If this value is `undefined`, then all attributes will be returned. | [String] | undefined |
+| consistent | Whether to perform a strongly consistent read or not. If this value is `undefined`, then no `ConsistentRead` parameter will be included in the request, and DynamoDB will default to an eventually consistent read. | boolean | undefined |
 
 ```js
 const User = dynamoose.model("User", {"id": Number, "name": String});

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -490,7 +490,7 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 			};
 
 			if (settings.consistent !== undefined && settings.consistent !== null) {
-				getItemParams.ConsistentRead = settings.consistent;
+				params.RequestItems[table.getInternalProperties(internalProperties).name].ConsistentRead = settings.consistent;
 			}
 			if (settings.attributes) {
 				params.RequestItems[table.getInternalProperties(internalProperties).name].AttributesToGet = settings.attributes;

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -87,6 +87,7 @@ interface ModelBatchGetItemsResponse<T> extends ItemArray<T> {
 interface ModelBatchGetSettings {
 	return?: "items" | "request";
 	attributes?: string[];
+	consistent?: boolean;
 }
 interface ModelBatchDeleteSettings {
 	return?: "response" | "request";
@@ -488,6 +489,9 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 				}
 			};
 
+			if (settings.consistent !== undefined && settings.consistent !== null) {
+				getItemParams.ConsistentRead = settings.consistent;
+			}
 			if (settings.attributes) {
 				params.RequestItems[table.getInternalProperties(internalProperties).name].AttributesToGet = settings.attributes;
 			}

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -1245,7 +1245,7 @@ describe("Model", () => {
 				});
 
 				it("Should send consistent (false) to batchGetItem", async () => {
-					getItemFunction = () => Promise.resolve({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}}]}, "UnprocessedKeys": {}});
+					promiseFunction = () => Promise.resolve({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}}]}, "UnprocessedKeys": {}});
 					await callType.func(User).bind(User)([1], {"consistent": false});
 					expect(params).toBeInstanceOf(Object);
 					expect(params).toEqual({
@@ -1261,7 +1261,7 @@ describe("Model", () => {
 				});
 
 				it("Should send consistent (true) to batchGetItem", async () => {
-					getItemFunction = () => Promise.resolve({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}}]}, "UnprocessedKeys": {}});
+					promiseFunction = () => Promise.resolve({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}}]}, "UnprocessedKeys": {}});
 					await callType.func(User).bind(User)([1], {"consistent": true});
 					expect(params).toBeInstanceOf(Object);
 					expect(params).toEqual({

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -1250,8 +1250,8 @@ describe("Model", () => {
 					expect(params).toBeInstanceOf(Object);
 					expect(params).toEqual({
 						"RequestItems": {
-							"ConsistentRead": false,
 							"User": {
+								"ConsistentRead": false,
 								"Keys": [
 									{"id": {"N": "1"}}
 								]
@@ -1266,8 +1266,8 @@ describe("Model", () => {
 					expect(params).toBeInstanceOf(Object);
 					expect(params).toEqual({
 						"RequestItems": {
-							"ConsistentRead": true,
 							"User": {
+								"ConsistentRead": true,
 								"Keys": [
 									{"id": {"N": "1"}}
 								]

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -1244,65 +1244,98 @@ describe("Model", () => {
 					});
 				});
 
-				it("Should send consistent (false) to batchGetItem", async () => {
-					promiseFunction = () => Promise.resolve({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}}]}, "UnprocessedKeys": {}});
-					await callType.func(User).bind(User)([1], {"consistent": false});
-					expect(params).toBeInstanceOf(Object);
-					expect(params).toEqual({
-						"RequestItems": {
-							"User": {
-								"ConsistentRead": false,
-								"Keys": [
-									{"id": {"N": "1"}}
-								]
+				describe("Consistent Read", () => {
+					it("Should not send consistent to batchGetItem if undefined", async () => {
+						promiseFunction = () => Promise.resolve({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}}]}, "UnprocessedKeys": {}});
+						await callType.func(User).bind(User)([1], {});
+						expect(params).toBeInstanceOf(Object);
+						expect(params).toEqual({
+							"RequestItems": {
+								"User": {
+									"Keys": [
+										{"id": {"N": "1"}}
+									]
+								}
 							}
-						}
+						});
 					});
-				});
 
-				it("Should send consistent (true) to batchGetItem", async () => {
-					promiseFunction = () => Promise.resolve({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}}]}, "UnprocessedKeys": {}});
-					await callType.func(User).bind(User)([1], {"consistent": true});
-					expect(params).toBeInstanceOf(Object);
-					expect(params).toEqual({
-						"RequestItems": {
-							"User": {
-								"ConsistentRead": true,
-								"Keys": [
-									{"id": {"N": "1"}}
-								]
+					it("Should not send consistent (false) to batchGetItem", async () => {
+						promiseFunction = () => Promise.resolve({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}}]}, "UnprocessedKeys": {}});
+						await callType.func(User).bind(User)([1], {"consistent": false});
+						expect(params).toBeInstanceOf(Object);
+						expect(params).toEqual({
+							"RequestItems": {
+								"User": {
+									"ConsistentRead": false,
+									"Keys": [
+										{"id": {"N": "1"}}
+									]
+								}
 							}
-						}
+						});
 					});
-				});
 
-				it("Should get consistent (false) back in request", async () => {
-					const result = await callType.func(User).bind(User)([1], {"return": "request", "consistent": false});
-					expect(params).not.toBeDefined();
-					expect(result).toEqual({
-						"RequestItems": {
-							"User": {
-								"ConsistentRead": false,
-								"Keys": [
-									{"id": {"N": "1"}}
-								]
+					it("Should send consistent (true) to batchGetItem", async () => {
+						promiseFunction = () => Promise.resolve({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}}]}, "UnprocessedKeys": {}});
+						await callType.func(User).bind(User)([1], {"consistent": true});
+						expect(params).toBeInstanceOf(Object);
+						expect(params).toEqual({
+							"RequestItems": {
+								"User": {
+									"ConsistentRead": true,
+									"Keys": [
+										{"id": {"N": "1"}}
+									]
+								}
 							}
-						}
+						});
 					});
-				});
 
-				it("Should get consistent (true) back in request", async () => {
-					const result = await callType.func(User).bind(User)([1], {"return": "request", "consistent": true});
-					expect(params).not.toBeDefined();
-					expect(result).toEqual({
-						"RequestItems": {
-							"User": {
-								"ConsistentRead": true,
-								"Keys": [
-									{"id": {"N": "1"}}
-								]
-							}
-						}
+					describe("Request Response", () => {
+						it("Should not get consistent back in request if undefined", async () => {
+							const result = await callType.func(User).bind(User)([1], {"return": "request"});
+							expect(params).not.toBeDefined();
+							expect(result).toEqual({
+								"RequestItems": {
+									"User": {
+										"Keys": [
+											{"id": {"N": "1"}}
+										]
+									}
+								}
+							});
+						});
+
+						it("Should not get consistent (false) back in request", async () => {
+							const result = await callType.func(User).bind(User)([1], {"return": "request", "consistent": false});
+							expect(params).not.toBeDefined();
+							expect(result).toEqual({
+								"RequestItems": {
+									"User": {
+										"ConsistentRead": false,
+										"Keys": [
+											{"id": {"N": "1"}}
+										]
+									}
+								}
+							});
+						});
+
+						it("Should get consistent (true) back in request", async () => {
+							const result = await callType.func(User).bind(User)([1], {"return": "request", "consistent": true});
+							expect(params).not.toBeDefined();
+							expect(result).toEqual({
+								"RequestItems": {
+									"User": {
+										"ConsistentRead": true,
+										"Keys": [
+											{"id": {"N": "1"}}
+										]
+									}
+								}
+							});
+						});
 					});
 				});
 

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -1244,6 +1244,68 @@ describe("Model", () => {
 					});
 				});
 
+				it("Should send consistent (false) to batchGetItem", async () => {
+					getItemFunction = () => Promise.resolve({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}}]}, "UnprocessedKeys": {}});
+					await callType.func(User).bind(User)([1], {"consistent": false});
+					expect(params).toBeInstanceOf(Object);
+					expect(params).toEqual({
+						"RequestItems": {
+							"ConsistentRead": false,
+							"User": {
+								"Keys": [
+									{"id": {"N": "1"}}
+								]
+							}
+						}
+					});
+				});
+
+				it("Should send consistent (true) to batchGetItem", async () => {
+					getItemFunction = () => Promise.resolve({"Responses": {"User": [{"id": {"N": "1"}, "name": {"S": "Charlie"}}]}, "UnprocessedKeys": {}});
+					await callType.func(User).bind(User)([1], {"consistent": true});
+					expect(params).toBeInstanceOf(Object);
+					expect(params).toEqual({
+						"RequestItems": {
+							"ConsistentRead": true,
+							"User": {
+								"Keys": [
+									{"id": {"N": "1"}}
+								]
+							}
+						}
+					});
+				});
+
+				it("Should get consistent (false) back in request", async () => {
+					const result = await callType.func(User).bind(User)([1], {"return": "request", "consistent": false});
+					expect(params).not.toBeDefined();
+					expect(result).toEqual({
+						"RequestItems": {
+							"User": {
+								"ConsistentRead": false,
+								"Keys": [
+									{"id": {"N": "1"}}
+								]
+							}
+						}
+					});
+				});
+
+				it("Should get consistent (true) back in request", async () => {
+					const result = await callType.func(User).bind(User)([1], {"return": "request", "consistent": true});
+					expect(params).not.toBeDefined();
+					expect(result).toEqual({
+						"RequestItems": {
+							"User": {
+								"ConsistentRead": true,
+								"Keys": [
+									{"id": {"N": "1"}}
+								]
+							}
+						}
+					});
+				});
+
 				it("Should throw error if setting option return to request and set function throws error", async () => {
 					const Item = dynamoose.model("Item", {"id": {
 						"type": Number,

--- a/packages/dynamoose/test/types/Model.ts
+++ b/packages/dynamoose/test/types/Model.ts
@@ -26,6 +26,8 @@ const shouldPassGetWithNoReturnSetting = model.get({"id": 1}, {"attributes": ["s
 const shouldPassDeleteWithNoReturnSetting = model.delete({"id": 1}, {"condition": new dynamoose.Condition("name").eq("Charlie")});
 const shouldPassUpdateWithNoReturnSetting = model.update({"id": 1}, {"name": "Charlie"}, {"condition": new dynamoose.Condition("name").eq("Bob")});
 const shouldPassBatchGetWithNoReturnSetting = model.batchGet([{"id": 1}, {"id": 2}], {});
+const shouldPassBatchGetWithConsistentTrue = model.batchGet([{"id": 1}, {"id": 2}], {"consistent": true});
+const shouldPassBatchGetWithConsistentFalse = model.batchGet([{"id": 1}, {"id": 2}], {"consistent": false});
 const shouldPassBatchPutWithNoReturnSetting = model.batchPut([{"id": 1}, {"id": 2}], {});
 const shouldPassBatchDeleteWithNoReturnSetting = model.batchDelete([{"id": 1}, {"id": 2}], {});
 const shouldPassCreateWithNoReturnSettingCallback = model.create({"id": 1}, {"overwrite": true}, () => {});
@@ -33,6 +35,8 @@ const shouldPassGetWithNoReturnSettingCallback = model.get({"id": 1}, {"attribut
 const shouldPassDeleteWithNoReturnSettingCallback = model.delete({"id": 1}, {"condition": new dynamoose.Condition("name").eq("Charlie")}, () => {});
 const shouldPassUpdateWithNoReturnSettingCallback = model.update({"id": 1}, {"name": "Charlie"}, {"condition": new dynamoose.Condition("name").eq("Bob")}, () => {});
 const shouldPassBatchGetWithNoReturnSettingCallback = model.batchGet([{"id": 1}, {"id": 2}], {}, () => {});
+const shouldPassBatchGetWithNoReturnSettingCallbackConsistentTrue = model.batchGet([{"id": 1}, {"id": 2}], {"consistent": true}, () => {});
+const shouldPassBatchGetWithNoReturnSettingCallbackConsistentFalse = model.batchGet([{"id": 1}, {"id": 2}], {"consistent": false}, () => {});
 const shouldPassBatchPutWithNoReturnSettingCallback = model.batchPut([{"id": 1}, {"id": 2}], {}, () => {});
 const shouldPassBatchDeleteWithNoReturnSettingCallback = model.batchDelete([{"id": 1}, {"id": 2}], {}, () => {});
 


### PR DESCRIPTION
### Summary:
Currently, the Dynamoose `model.batchGet()` method does not support setting consistent reads although the [DynamoDB BatchGetItems](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html) does support consistent reads. This PR adds `consistent` as a setting to the `model.batchGet()` method settings.



<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:

#### Model
```
const User = dynamoose.model("User", {"id": Number, "name": String});
const myUsers = await User.batchGet([1, 2], {"consistent": true});
```

### Type (select 1):
- [ ] Bug fix
- [x] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
