### PR TITLE
Only include ./dist in npm package

### DIFF
--- a/packages/dynamoose/package.json
+++ b/packages/dynamoose/package.json
@@ -5,6 +5,9 @@
   "homepage": "https://dynamoosejs.com",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dynamoose/dynamoose.git"


### PR DESCRIPTION
### Summary:
Use `files` in the published package.json to only publish the `dist` folder. The currently [published package](https://www.npmjs.com/package/dynamoose?activeTab=explore) includes a lot of unnecessary files (./lib, and ./test in particular), removing them will be a meaningful reduction in package size for everyone using dynamoose.

### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #---- @---)
- [x] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No

### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
