### PR TITLE
move '@aws-sdk' modules from 'dependencies' to 'peerDependencies'

### DIFF
--- a/packages/dynamoose/package-lock.json
+++ b/packages/dynamoose/package-lock.json
@@ -19,13 +19,15 @@
       ],
       "license": "Unlicense",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.142.0",
-        "@aws-sdk/util-dynamodb": "^3.142.0",
-        "dynamoose-utils": "^3.0.0-beta.6",
+        "dynamoose-utils": "^3.1.0",
         "js-object-utilities": "^2.1.0"
       },
       "devDependencies": {
-        "dynamoose-logger": "^3.0.0-beta.6"
+        "dynamoose-logger": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.142.0",
+        "@aws-sdk/util-dynamodb": "^3.142.0"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -33,6 +35,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto%2fie11-detection/-/ie11-detection-2.0.0.tgz",
       "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -41,13 +44,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto%2fsha256-browser/-/sha256-browser-2.0.0.tgz",
       "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -63,13 +68,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto%2fsha256-js/-/sha256-js-2.0.0.tgz",
       "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -80,13 +87,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto%2fsupports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
       "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -95,13 +104,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/@aws-crypto/util": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-crypto%2futil/-/util-2.0.1.tgz",
       "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -112,13 +123,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/@aws-sdk/abort-controller": {
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fabort-controller/-/abort-controller-3.127.0.tgz",
       "integrity": "sha512-G77FLYcl9egUoD3ZmR6TX94NMqBMeT53hBGrEE3uVUJV1CwfGKfaF007mPpRZnIB3avnJBQGEK6MrwlCfv2qAw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -132,6 +145,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fclient-dynamodb/-/client-dynamodb-3.142.0.tgz",
       "integrity": "sha512-VAc0rpxAyetDrdqJnJw0GL2cq7JxBZsn2FTdxAYTas9id622ZgnItQdqCQ1XbXT2VV9QcbOFIP5ihy6G1QDn9g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -180,6 +194,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fclient-sso/-/client-sso-3.142.0.tgz",
       "integrity": "sha512-Pewcpxq+wqcbB3t3s6KImBUUf+qqBNqMfd2wgQ3PdpYBjlNzrWYLHAnIT1vhIFjOGJXDi/qwF8FX7qbWNUB7Lg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -222,6 +237,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fclient-sts/-/client-sts-3.142.0.tgz",
       "integrity": "sha512-rOa1MTI1h3kTjlHkItAlXGHefM5sjsfw3muhNEhzrZBuhpOrLU8apbiG2rcJqB8m0prMoY39PuG+WquxN4ap6g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -269,6 +285,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fconfig-resolver/-/config-resolver-3.130.0.tgz",
       "integrity": "sha512-7dkCHHI9kRcHW6YNr9/2Ub6XkvU9Fu6H/BnlKbaKlDR8jq7QpaFhPhctOVi5D/NDpxJgALifexFne0dvo3piTw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/signature-v4": "3.130.0",
         "@aws-sdk/types": "3.127.0",
@@ -285,6 +302,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-env/-/credential-provider-env-3.127.0.tgz",
       "integrity": "sha512-Ig7XhUikRBlnRTYT5JBGzWfYZp68X5vkFVIFCmsHHt/qVy0Nz9raZpmDHicdS1u67yxDkWgCPn/bNevWnM0GFg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -299,6 +317,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-imds/-/credential-provider-imds-3.127.0.tgz",
       "integrity": "sha512-I6KlIBBzmJn/U1KikiC50PK3SspT9G5lkVLBaW5a6YfOcijqVTXfAN3kYzqhfeS0j4IgfJEwKVsjsZfmprJO5A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
@@ -315,6 +334,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-ini/-/credential-provider-ini-3.142.0.tgz",
       "integrity": "sha512-joMJTxUTNmxURnVmmd7XhtwOwijMjh7z09V8o2EHQMk+ak+rhaRgqb2kTA2nO0J3SRxdO5z5SKkyQgW0d1fY9g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
@@ -334,6 +354,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-node/-/credential-provider-node-3.142.0.tgz",
       "integrity": "sha512-JkhCKNkEhCS2vgD/qg5hJPatupNLObqts9FXiDia5CF6w8YcHLH+mWSvhUMCUGkunAOvFHDkQL1uPXfoQuJvPg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
@@ -355,6 +376,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-process/-/credential-provider-process-3.127.0.tgz",
       "integrity": "sha512-6v0m2lqkO9J5fNlTl+HjriQNIdfg8mjVST544+5y9EnC/FVmTnIz64vfHveWdNkP/fehFx7wTimNENtoSqCn3A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -370,6 +392,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-sso/-/credential-provider-sso-3.142.0.tgz",
       "integrity": "sha512-jJvp/A5xrikaeL0DhjhQTvUc0+eF0hN5Nbo+nxpnUOiOOkyqs329g65NI1TmLp/OzDcqQ/8p5vj2+7ufTGEOXQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.142.0",
         "@aws-sdk/property-provider": "3.127.0",
@@ -386,6 +409,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-web-identity/-/credential-provider-web-identity-3.127.0.tgz",
       "integrity": "sha512-85ahDZnLYB3dqkW+cQ0bWt+NVqOoxomTrJoq3IC2q6muebeFrJ0pyf0JEW/RNRzBiUvvsZujzGdWifzWyQKfVg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -400,6 +424,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fendpoint-cache/-/endpoint-cache-3.55.0.tgz",
       "integrity": "sha512-kxDoHFDuQwZEEUZRp+ZLOg68EXuKPzUN86DcpIZantDVcmu7MSPTbbQp9DZd8MnKVEKCP7Sop5f7zCqOPl3LXw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.3.1"
@@ -413,6 +438,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2ffetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
       "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/querystring-builder": "3.127.0",
@@ -426,6 +452,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fhash-node/-/hash-node-3.127.0.tgz",
       "integrity": "sha512-wx7DKlXdKebH4JcMsOevdsm2oDNMVm36kuMm0XWRIrFWQ/oq7OquDpEMJzWvGqWF/IfFUpb7FhAWZZpALwlcwA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/util-buffer-from": "3.55.0",
@@ -440,6 +467,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2finvalid-dependency/-/invalid-dependency-3.127.0.tgz",
       "integrity": "sha512-bxvmtmJ6gIRfOHvh1jAPZBH2mzppEblPjEOFo4mOzXz4U3qPIxeuukCjboMnGK9QEpV2wObWcYYld0vxoRrfiA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -450,6 +478,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fis-array-buffer/-/is-array-buffer-3.55.0.tgz",
       "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -462,6 +491,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-content-length/-/middleware-content-length-3.127.0.tgz",
       "integrity": "sha512-AFmMaIEW3Rzg0TaKB9l/RENLowd7ZEEOpm0trYw1CgUUORWW/ydCsDT7pekPlC25CPbhUmWXCSA4xPFSYOVnDw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -476,6 +506,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-endpoint-discovery/-/middleware-endpoint-discovery-3.130.0.tgz",
       "integrity": "sha512-CvxSnJmAxnJyIL9E7Du8S2oocYCpMFNSQ3blUKUM6+YUuEfZJpSTAZUjbB5tVneBgBhFVKAoQ5T6LORtOJLXqA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/config-resolver": "3.130.0",
         "@aws-sdk/endpoint-cache": "3.55.0",
@@ -492,6 +523,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-host-header/-/middleware-host-header-3.127.0.tgz",
       "integrity": "sha512-e2gTLJb5lYP9lRV7hN3rKY2l4jv8OygOoHElZJ3Z8KPZskjHelYPcQ8XbdfhSXXxC3vc/0QqN0ResFt3W3Pplg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -506,6 +538,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-logger/-/middleware-logger-3.127.0.tgz",
       "integrity": "sha512-jMNLcZB/ECA7OfkNBLNeAlrLRehyfnUeNQJHW3kcxs9h1+6VxaF6wY+WKozszLI7/3OBzQrFHBQCfRZV7ykSLg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -519,6 +552,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-recursion-detection/-/middleware-recursion-detection-3.127.0.tgz",
       "integrity": "sha512-tB6WX+Z1kUKTnn5h38XFrTCzoqPKjUZLUjN4Wb27/cbeSiTSKGAZcCXHOJm36Ukorl5arlybQTqGe689EU00Hw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -533,6 +567,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-retry/-/middleware-retry-3.127.0.tgz",
       "integrity": "sha512-ZSvg/AyGUacWnf3i8ZbyImtiCH+NyafF8uV7bITP7JkwPrG+VdNocJZOr88GRM0c1A0jfkOf7+oq+fInPwwiNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/service-error-classification": "3.127.0",
@@ -550,6 +585,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-sdk-sts/-/middleware-sdk-sts-3.130.0.tgz",
       "integrity": "sha512-FDfs7+ohbhEK3eH3Dshr6JDiL8P72bp3ffeNpPBXuURFqwt4pCmjHuX3SqQR0JIJ2cl3aIdxc17rKaZJfOjtPw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-signing": "3.130.0",
         "@aws-sdk/property-provider": "3.127.0",
@@ -567,6 +603,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-serde/-/middleware-serde-3.127.0.tgz",
       "integrity": "sha512-xmWMYV/t9M+b9yHjqaD1noDNJJViI2QwOH7TQZ9VbbrvdVtDrFuS9Sf9He80TBCJqeHShwQN9783W1I3Pu/8kw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -580,6 +617,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-signing/-/middleware-signing-3.130.0.tgz",
       "integrity": "sha512-JePq5XLR9TfRN3RQ0d7Za/bEW5D3xgtD1FNAwHeenWALeozMuQgRPjM5RroCnL/5jY3wuvCZI7cSXeqhawWqmA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
@@ -596,6 +634,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-stack/-/middleware-stack-3.127.0.tgz",
       "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -608,6 +647,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-user-agent/-/middleware-user-agent-3.127.0.tgz",
       "integrity": "sha512-CHxgswoOzdkOEoIq7Oyob3Sx/4FYUv6BhUesAX7MNshaDDsTQPbSWjw5bqZDiL/gO+X/34fvqCVVpVD2GvxW/g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -622,6 +662,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fnode-config-provider/-/node-config-provider-3.127.0.tgz",
       "integrity": "sha512-bAHkASMhLZHT1yv2TX6OJGFV9Lc3t1gKfTMEKdXM2O2YhGfSx9A/qLeJm79oDfnILWQtSS2NicxlRDI2lYGf4g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -637,6 +678,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fnode-http-handler/-/node-http-handler-3.127.0.tgz",
       "integrity": "sha512-pyMKvheK8eDwWLgYIRsWy8wiyhsbYYcqkZQs3Eh6upI4E8iCY7eMmhWvHYCibvsO+UjsOwa4cAMOfwnv/Z9s8A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
@@ -653,6 +695,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fproperty-provider/-/property-provider-3.127.0.tgz",
       "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -666,6 +709,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fprotocol-http/-/protocol-http-3.127.0.tgz",
       "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -679,6 +723,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fquerystring-builder/-/querystring-builder-3.127.0.tgz",
       "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/util-uri-escape": "3.55.0",
@@ -693,6 +738,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fquerystring-parser/-/querystring-parser-3.127.0.tgz",
       "integrity": "sha512-Vn/Dv+PqUSepp/DzLqq0LJJD8HdPefJCnLbO5WcHCARHSGlyGlZUFEM45k/oEHpTvgMXj/ORaP3A+tLwLu0AmA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -706,6 +752,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fservice-error-classification/-/service-error-classification-3.127.0.tgz",
       "integrity": "sha512-wjZY9rnlA8SPrICUumTYicEKtK4/yKB62iadUk66hxe8MrH8JhuHH2NqIad0Pt/bK/YtNVhd3yb4pRapOeY5qQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -715,6 +762,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fshared-ini-file-loader/-/shared-ini-file-loader-3.127.0.tgz",
       "integrity": "sha512-S3Nn4KRTqoJsB/TbRZSWBBUrkckNMR0Juqz7bOB+wupVvddKP6IcpspSC/GX9zgJjVMV8iGisZ6AUsYsC5r+cA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -727,6 +775,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fsignature-v4/-/signature-v4-3.130.0.tgz",
       "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.55.0",
         "@aws-sdk/types": "3.127.0",
@@ -744,6 +793,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fsmithy-client/-/smithy-client-3.142.0.tgz",
       "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -758,6 +808,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2ftypes/-/types-3.127.0.tgz",
       "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -767,6 +818,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2furl-parser/-/url-parser-3.127.0.tgz",
       "integrity": "sha512-njZ7zn41JHRpNfr3BCesVXCLZE0zcWSfEdtRV0ICw0cU1FgYcKELSuY9+gLUB4ci6uc7gq7mPE8+w30FcM4QeA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/querystring-parser": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -778,6 +830,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-base64-browser/-/util-base64-browser-3.109.0.tgz",
       "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -787,6 +840,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-base64-node/-/util-base64-node-3.55.0.tgz",
       "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
@@ -800,6 +854,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
       "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -809,6 +864,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-body-length-node/-/util-body-length-node-3.55.0.tgz",
       "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -821,6 +877,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-buffer-from/-/util-buffer-from-3.55.0.tgz",
       "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.55.0",
         "tslib": "^2.3.1"
@@ -834,6 +891,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-config-provider/-/util-config-provider-3.109.0.tgz",
       "integrity": "sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -846,6 +904,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-defaults-mode-browser/-/util-defaults-mode-browser-3.142.0.tgz",
       "integrity": "sha512-vVB/CrodMmIfv4v54MyBlKO0sQSI/+Mvs4g5gMyVjmT4a+1gnktJQ9R6ZHQ2/ErGewcra6eH9MU5T0r1kYe0+w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -861,6 +920,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-defaults-mode-node/-/util-defaults-mode-node-3.142.0.tgz",
       "integrity": "sha512-13d5RZLO13EDwll3COUq3D4KVsqM63kdf+YjG5mzXR1eXo6GVjghfQfiy0MYM6YbAjTfJxZQkc0nFgWLU8jdyg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/config-resolver": "3.130.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
@@ -878,6 +938,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-dynamodb/-/util-dynamodb-3.142.0.tgz",
       "integrity": "sha512-imJxJxiZcB50X4/MIe2d4hrKcGPTJQwatbdqp8dpm2NgMzZYp4DMsSPw7J+Q2V2JdmMJ4pPJ2ZKntg/oAnqqJA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -890,6 +951,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
       "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -902,6 +964,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-locate-window/-/util-locate-window-3.55.0.tgz",
       "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -914,6 +977,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-middleware/-/util-middleware-3.127.0.tgz",
       "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -926,6 +990,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-uri-escape/-/util-uri-escape-3.55.0.tgz",
       "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -938,6 +1003,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-user-agent-browser/-/util-user-agent-browser-3.127.0.tgz",
       "integrity": "sha512-uO2oHmJswuYKJS+GiMdYI8izhpC9M7/jFFvnAmLlTEVwpEi1VX9KePAOF+u5AaBC2kzITo/7dg141XfRHZloIQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.127.0",
         "bowser": "^2.11.0",
@@ -949,6 +1015,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-user-agent-node/-/util-user-agent-node-3.127.0.tgz",
       "integrity": "sha512-3P/M4ZDD2qMeeoCk7TE/Mw7cG5IjB87F6BP8nI8/oHuaz7j6fsI7D49SNpyjl8JApRynZ122Ad6hwQwRj3isYw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -971,6 +1038,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
       "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -980,6 +1048,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-utf8-node/-/util-utf8-node-3.109.0.tgz",
       "integrity": "sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
@@ -993,6 +1062,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-waiter/-/util-waiter-3.127.0.tgz",
       "integrity": "sha512-E5qrRpBJS8dmClqSDW1pWVMKzCG/mxabG6jVUtlW/WLHnl/znxGaOQc6tnnwKik0nEq/4DpT9fEfPUz9JiLrkw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1006,12 +1076,13 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dynamoose-logger": {
-      "version": "3.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/dynamoose-logger/-/dynamoose-logger-3.0.0-beta.6.tgz",
-      "integrity": "sha512-VWumjBazD+CTi+hmduD99T8s4+lf1vWksEgSPfcUVaZxOuEKuFb1cN9f8cnuAGD5Y0Mz+jwJlMwlB4KqUK42Vg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/dynamoose-logger/-/dynamoose-logger-3.1.0.tgz",
+      "integrity": "sha512-TNo6Eknj9Sgl5Ek9yTw0IycuXAHSqqHZ4ViJKlOz8uL96CJBURnWZ1Bt0R6QyuFWZbfz9TfLbNfv+EYBaUxp6A==",
       "dev": true,
       "funding": [
         {
@@ -1023,17 +1094,16 @@
           "url": "https://opencollective.com/dynamoose"
         }
       ],
-      "license": "Unlicense",
       "dependencies": {
-        "dynamoose-utils": "^3.0.0-beta.6",
+        "dynamoose-utils": "^3.1.0",
         "js-object-utilities": "^2.1.0",
         "uuid": "^8.3.2"
       }
     },
     "node_modules/dynamoose-utils": {
-      "version": "3.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.0.0-beta.6.tgz",
-      "integrity": "sha512-8DPvCUff7bqC2tM6B4uvJf/Qik0cKcDCJysvEsuJy1OdhBMFM7+UgtO6ZbmlZqOQCCxpycu0Ix16uHH1sRX+Zw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.1.0.tgz",
+      "integrity": "sha512-HeSR4H9HvhQM2zb+4LuQlfQMHYCSn9aSsAyDArUlqfLn3cDCfrYN/HBMVTv8pNkqOakAB7MlYOW7ubDThbsvKQ==",
       "funding": [
         {
           "type": "github-sponsors",
@@ -1044,7 +1114,6 @@
           "url": "https://opencollective.com/dynamoose"
         }
       ],
-      "license": "Unlicense",
       "dependencies": {
         "js-object-utilities": "^2.1.0"
       }
@@ -1054,6 +1123,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -1063,6 +1133,7 @@
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
       "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "xml2js": "cli.js"
       },
@@ -1082,6 +1153,7 @@
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -1090,13 +1162,15 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -1113,6 +1187,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto%2fie11-detection/-/ie11-detection-2.0.0.tgz",
       "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "peer": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -1120,7 +1195,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -1128,6 +1204,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto%2fsha256-browser/-/sha256-browser-2.0.0.tgz",
       "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "peer": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -1142,7 +1219,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -1150,6 +1228,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto%2fsha256-js/-/sha256-js-2.0.0.tgz",
       "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "peer": true,
       "requires": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -1159,7 +1238,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -1167,6 +1247,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto%2fsupports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
       "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "peer": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -1174,7 +1255,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -1182,6 +1264,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-crypto%2futil/-/util-2.0.1.tgz",
       "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -1191,7 +1274,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -1199,6 +1283,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fabort-controller/-/abort-controller-3.127.0.tgz",
       "integrity": "sha512-G77FLYcl9egUoD3ZmR6TX94NMqBMeT53hBGrEE3uVUJV1CwfGKfaF007mPpRZnIB3avnJBQGEK6MrwlCfv2qAw==",
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -1208,6 +1293,7 @@
       "version": "3.142.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fclient-dynamodb/-/client-dynamodb-3.142.0.tgz",
       "integrity": "sha512-VAc0rpxAyetDrdqJnJw0GL2cq7JxBZsn2FTdxAYTas9id622ZgnItQdqCQ1XbXT2VV9QcbOFIP5ihy6G1QDn9g==",
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -1252,6 +1338,7 @@
       "version": "3.142.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fclient-sso/-/client-sso-3.142.0.tgz",
       "integrity": "sha512-Pewcpxq+wqcbB3t3s6KImBUUf+qqBNqMfd2wgQ3PdpYBjlNzrWYLHAnIT1vhIFjOGJXDi/qwF8FX7qbWNUB7Lg==",
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -1290,6 +1377,7 @@
       "version": "3.142.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fclient-sts/-/client-sts-3.142.0.tgz",
       "integrity": "sha512-rOa1MTI1h3kTjlHkItAlXGHefM5sjsfw3muhNEhzrZBuhpOrLU8apbiG2rcJqB8m0prMoY39PuG+WquxN4ap6g==",
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -1333,6 +1421,7 @@
       "version": "3.130.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fconfig-resolver/-/config-resolver-3.130.0.tgz",
       "integrity": "sha512-7dkCHHI9kRcHW6YNr9/2Ub6XkvU9Fu6H/BnlKbaKlDR8jq7QpaFhPhctOVi5D/NDpxJgALifexFne0dvo3piTw==",
+      "peer": true,
       "requires": {
         "@aws-sdk/signature-v4": "3.130.0",
         "@aws-sdk/types": "3.127.0",
@@ -1345,6 +1434,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-env/-/credential-provider-env-3.127.0.tgz",
       "integrity": "sha512-Ig7XhUikRBlnRTYT5JBGzWfYZp68X5vkFVIFCmsHHt/qVy0Nz9raZpmDHicdS1u67yxDkWgCPn/bNevWnM0GFg==",
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1355,6 +1445,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-imds/-/credential-provider-imds-3.127.0.tgz",
       "integrity": "sha512-I6KlIBBzmJn/U1KikiC50PK3SspT9G5lkVLBaW5a6YfOcijqVTXfAN3kYzqhfeS0j4IgfJEwKVsjsZfmprJO5A==",
+      "peer": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
@@ -1367,6 +1458,7 @@
       "version": "3.142.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-ini/-/credential-provider-ini-3.142.0.tgz",
       "integrity": "sha512-joMJTxUTNmxURnVmmd7XhtwOwijMjh7z09V8o2EHQMk+ak+rhaRgqb2kTA2nO0J3SRxdO5z5SKkyQgW0d1fY9g==",
+      "peer": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
@@ -1382,6 +1474,7 @@
       "version": "3.142.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-node/-/credential-provider-node-3.142.0.tgz",
       "integrity": "sha512-JkhCKNkEhCS2vgD/qg5hJPatupNLObqts9FXiDia5CF6w8YcHLH+mWSvhUMCUGkunAOvFHDkQL1uPXfoQuJvPg==",
+      "peer": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
@@ -1399,6 +1492,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-process/-/credential-provider-process-3.127.0.tgz",
       "integrity": "sha512-6v0m2lqkO9J5fNlTl+HjriQNIdfg8mjVST544+5y9EnC/FVmTnIz64vfHveWdNkP/fehFx7wTimNENtoSqCn3A==",
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -1410,6 +1504,7 @@
       "version": "3.142.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-sso/-/credential-provider-sso-3.142.0.tgz",
       "integrity": "sha512-jJvp/A5xrikaeL0DhjhQTvUc0+eF0hN5Nbo+nxpnUOiOOkyqs329g65NI1TmLp/OzDcqQ/8p5vj2+7ufTGEOXQ==",
+      "peer": true,
       "requires": {
         "@aws-sdk/client-sso": "3.142.0",
         "@aws-sdk/property-provider": "3.127.0",
@@ -1422,6 +1517,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fcredential-provider-web-identity/-/credential-provider-web-identity-3.127.0.tgz",
       "integrity": "sha512-85ahDZnLYB3dqkW+cQ0bWt+NVqOoxomTrJoq3IC2q6muebeFrJ0pyf0JEW/RNRzBiUvvsZujzGdWifzWyQKfVg==",
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1432,6 +1528,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fendpoint-cache/-/endpoint-cache-3.55.0.tgz",
       "integrity": "sha512-kxDoHFDuQwZEEUZRp+ZLOg68EXuKPzUN86DcpIZantDVcmu7MSPTbbQp9DZd8MnKVEKCP7Sop5f7zCqOPl3LXw==",
+      "peer": true,
       "requires": {
         "mnemonist": "0.38.3",
         "tslib": "^2.3.1"
@@ -1441,6 +1538,7 @@
       "version": "3.131.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2ffetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
       "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/querystring-builder": "3.127.0",
@@ -1453,6 +1551,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fhash-node/-/hash-node-3.127.0.tgz",
       "integrity": "sha512-wx7DKlXdKebH4JcMsOevdsm2oDNMVm36kuMm0XWRIrFWQ/oq7OquDpEMJzWvGqWF/IfFUpb7FhAWZZpALwlcwA==",
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/util-buffer-from": "3.55.0",
@@ -1463,6 +1562,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2finvalid-dependency/-/invalid-dependency-3.127.0.tgz",
       "integrity": "sha512-bxvmtmJ6gIRfOHvh1jAPZBH2mzppEblPjEOFo4mOzXz4U3qPIxeuukCjboMnGK9QEpV2wObWcYYld0vxoRrfiA==",
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -1472,6 +1572,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fis-array-buffer/-/is-array-buffer-3.55.0.tgz",
       "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1480,6 +1581,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-content-length/-/middleware-content-length-3.127.0.tgz",
       "integrity": "sha512-AFmMaIEW3Rzg0TaKB9l/RENLowd7ZEEOpm0trYw1CgUUORWW/ydCsDT7pekPlC25CPbhUmWXCSA4xPFSYOVnDw==",
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1490,6 +1592,7 @@
       "version": "3.130.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-endpoint-discovery/-/middleware-endpoint-discovery-3.130.0.tgz",
       "integrity": "sha512-CvxSnJmAxnJyIL9E7Du8S2oocYCpMFNSQ3blUKUM6+YUuEfZJpSTAZUjbB5tVneBgBhFVKAoQ5T6LORtOJLXqA==",
+      "peer": true,
       "requires": {
         "@aws-sdk/config-resolver": "3.130.0",
         "@aws-sdk/endpoint-cache": "3.55.0",
@@ -1502,6 +1605,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-host-header/-/middleware-host-header-3.127.0.tgz",
       "integrity": "sha512-e2gTLJb5lYP9lRV7hN3rKY2l4jv8OygOoHElZJ3Z8KPZskjHelYPcQ8XbdfhSXXxC3vc/0QqN0ResFt3W3Pplg==",
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1512,6 +1616,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-logger/-/middleware-logger-3.127.0.tgz",
       "integrity": "sha512-jMNLcZB/ECA7OfkNBLNeAlrLRehyfnUeNQJHW3kcxs9h1+6VxaF6wY+WKozszLI7/3OBzQrFHBQCfRZV7ykSLg==",
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -1521,6 +1626,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-recursion-detection/-/middleware-recursion-detection-3.127.0.tgz",
       "integrity": "sha512-tB6WX+Z1kUKTnn5h38XFrTCzoqPKjUZLUjN4Wb27/cbeSiTSKGAZcCXHOJm36Ukorl5arlybQTqGe689EU00Hw==",
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1531,6 +1637,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-retry/-/middleware-retry-3.127.0.tgz",
       "integrity": "sha512-ZSvg/AyGUacWnf3i8ZbyImtiCH+NyafF8uV7bITP7JkwPrG+VdNocJZOr88GRM0c1A0jfkOf7+oq+fInPwwiNA==",
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/service-error-classification": "3.127.0",
@@ -1544,6 +1651,7 @@
       "version": "3.130.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-sdk-sts/-/middleware-sdk-sts-3.130.0.tgz",
       "integrity": "sha512-FDfs7+ohbhEK3eH3Dshr6JDiL8P72bp3ffeNpPBXuURFqwt4pCmjHuX3SqQR0JIJ2cl3aIdxc17rKaZJfOjtPw==",
+      "peer": true,
       "requires": {
         "@aws-sdk/middleware-signing": "3.130.0",
         "@aws-sdk/property-provider": "3.127.0",
@@ -1557,6 +1665,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-serde/-/middleware-serde-3.127.0.tgz",
       "integrity": "sha512-xmWMYV/t9M+b9yHjqaD1noDNJJViI2QwOH7TQZ9VbbrvdVtDrFuS9Sf9He80TBCJqeHShwQN9783W1I3Pu/8kw==",
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -1566,6 +1675,7 @@
       "version": "3.130.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-signing/-/middleware-signing-3.130.0.tgz",
       "integrity": "sha512-JePq5XLR9TfRN3RQ0d7Za/bEW5D3xgtD1FNAwHeenWALeozMuQgRPjM5RroCnL/5jY3wuvCZI7cSXeqhawWqmA==",
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
@@ -1578,6 +1688,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-stack/-/middleware-stack-3.127.0.tgz",
       "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1586,6 +1697,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fmiddleware-user-agent/-/middleware-user-agent-3.127.0.tgz",
       "integrity": "sha512-CHxgswoOzdkOEoIq7Oyob3Sx/4FYUv6BhUesAX7MNshaDDsTQPbSWjw5bqZDiL/gO+X/34fvqCVVpVD2GvxW/g==",
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1596,6 +1708,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fnode-config-provider/-/node-config-provider-3.127.0.tgz",
       "integrity": "sha512-bAHkASMhLZHT1yv2TX6OJGFV9Lc3t1gKfTMEKdXM2O2YhGfSx9A/qLeJm79oDfnILWQtSS2NicxlRDI2lYGf4g==",
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -1607,6 +1720,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fnode-http-handler/-/node-http-handler-3.127.0.tgz",
       "integrity": "sha512-pyMKvheK8eDwWLgYIRsWy8wiyhsbYYcqkZQs3Eh6upI4E8iCY7eMmhWvHYCibvsO+UjsOwa4cAMOfwnv/Z9s8A==",
+      "peer": true,
       "requires": {
         "@aws-sdk/abort-controller": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
@@ -1619,6 +1733,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fproperty-provider/-/property-provider-3.127.0.tgz",
       "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -1628,6 +1743,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fprotocol-http/-/protocol-http-3.127.0.tgz",
       "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -1637,6 +1753,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fquerystring-builder/-/querystring-builder-3.127.0.tgz",
       "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/util-uri-escape": "3.55.0",
@@ -1647,6 +1764,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fquerystring-parser/-/querystring-parser-3.127.0.tgz",
       "integrity": "sha512-Vn/Dv+PqUSepp/DzLqq0LJJD8HdPefJCnLbO5WcHCARHSGlyGlZUFEM45k/oEHpTvgMXj/ORaP3A+tLwLu0AmA==",
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.127.0",
         "tslib": "^2.3.1"
@@ -1655,12 +1773,14 @@
     "@aws-sdk/service-error-classification": {
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fservice-error-classification/-/service-error-classification-3.127.0.tgz",
-      "integrity": "sha512-wjZY9rnlA8SPrICUumTYicEKtK4/yKB62iadUk66hxe8MrH8JhuHH2NqIad0Pt/bK/YtNVhd3yb4pRapOeY5qQ=="
+      "integrity": "sha512-wjZY9rnlA8SPrICUumTYicEKtK4/yKB62iadUk66hxe8MrH8JhuHH2NqIad0Pt/bK/YtNVhd3yb4pRapOeY5qQ==",
+      "peer": true
     },
     "@aws-sdk/shared-ini-file-loader": {
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fshared-ini-file-loader/-/shared-ini-file-loader-3.127.0.tgz",
       "integrity": "sha512-S3Nn4KRTqoJsB/TbRZSWBBUrkckNMR0Juqz7bOB+wupVvddKP6IcpspSC/GX9zgJjVMV8iGisZ6AUsYsC5r+cA==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1669,6 +1789,7 @@
       "version": "3.130.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fsignature-v4/-/signature-v4-3.130.0.tgz",
       "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
+      "peer": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.55.0",
         "@aws-sdk/types": "3.127.0",
@@ -1682,6 +1803,7 @@
       "version": "3.142.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2fsmithy-client/-/smithy-client-3.142.0.tgz",
       "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
+      "peer": true,
       "requires": {
         "@aws-sdk/middleware-stack": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1691,12 +1813,14 @@
     "@aws-sdk/types": {
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2ftypes/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "peer": true
     },
     "@aws-sdk/url-parser": {
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2furl-parser/-/url-parser-3.127.0.tgz",
       "integrity": "sha512-njZ7zn41JHRpNfr3BCesVXCLZE0zcWSfEdtRV0ICw0cU1FgYcKELSuY9+gLUB4ci6uc7gq7mPE8+w30FcM4QeA==",
+      "peer": true,
       "requires": {
         "@aws-sdk/querystring-parser": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1707,6 +1831,7 @@
       "version": "3.109.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-base64-browser/-/util-base64-browser-3.109.0.tgz",
       "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1715,6 +1840,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-base64-node/-/util-base64-node-3.55.0.tgz",
       "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
+      "peer": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
@@ -1724,6 +1850,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
       "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1732,6 +1859,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-body-length-node/-/util-body-length-node-3.55.0.tgz",
       "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1740,6 +1868,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-buffer-from/-/util-buffer-from-3.55.0.tgz",
       "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+      "peer": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.55.0",
         "tslib": "^2.3.1"
@@ -1749,6 +1878,7 @@
       "version": "3.109.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-config-provider/-/util-config-provider-3.109.0.tgz",
       "integrity": "sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1757,6 +1887,7 @@
       "version": "3.142.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-defaults-mode-browser/-/util-defaults-mode-browser-3.142.0.tgz",
       "integrity": "sha512-vVB/CrodMmIfv4v54MyBlKO0sQSI/+Mvs4g5gMyVjmT4a+1gnktJQ9R6ZHQ2/ErGewcra6eH9MU5T0r1kYe0+w==",
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1768,6 +1899,7 @@
       "version": "3.142.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-defaults-mode-node/-/util-defaults-mode-node-3.142.0.tgz",
       "integrity": "sha512-13d5RZLO13EDwll3COUq3D4KVsqM63kdf+YjG5mzXR1eXo6GVjghfQfiy0MYM6YbAjTfJxZQkc0nFgWLU8jdyg==",
+      "peer": true,
       "requires": {
         "@aws-sdk/config-resolver": "3.130.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
@@ -1781,6 +1913,7 @@
       "version": "3.142.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-dynamodb/-/util-dynamodb-3.142.0.tgz",
       "integrity": "sha512-imJxJxiZcB50X4/MIe2d4hrKcGPTJQwatbdqp8dpm2NgMzZYp4DMsSPw7J+Q2V2JdmMJ4pPJ2ZKntg/oAnqqJA==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1789,6 +1922,7 @@
       "version": "3.109.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
       "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1797,6 +1931,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-locate-window/-/util-locate-window-3.55.0.tgz",
       "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1805,6 +1940,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-middleware/-/util-middleware-3.127.0.tgz",
       "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1813,6 +1949,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-uri-escape/-/util-uri-escape-3.55.0.tgz",
       "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1821,6 +1958,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-user-agent-browser/-/util-user-agent-browser-3.127.0.tgz",
       "integrity": "sha512-uO2oHmJswuYKJS+GiMdYI8izhpC9M7/jFFvnAmLlTEVwpEi1VX9KePAOF+u5AaBC2kzITo/7dg141XfRHZloIQ==",
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.127.0",
         "bowser": "^2.11.0",
@@ -1831,6 +1969,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-user-agent-node/-/util-user-agent-node-3.127.0.tgz",
       "integrity": "sha512-3P/M4ZDD2qMeeoCk7TE/Mw7cG5IjB87F6BP8nI8/oHuaz7j6fsI7D49SNpyjl8JApRynZ122Ad6hwQwRj3isYw==",
+      "peer": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1841,6 +1980,7 @@
       "version": "3.109.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
       "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -1849,6 +1989,7 @@
       "version": "3.109.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-utf8-node/-/util-utf8-node-3.109.0.tgz",
       "integrity": "sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==",
+      "peer": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
@@ -1858,6 +1999,7 @@
       "version": "3.127.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk%2futil-waiter/-/util-waiter-3.127.0.tgz",
       "integrity": "sha512-E5qrRpBJS8dmClqSDW1pWVMKzCG/mxabG6jVUtlW/WLHnl/znxGaOQc6tnnwKik0nEq/4DpT9fEfPUz9JiLrkw==",
+      "peer": true,
       "requires": {
         "@aws-sdk/abort-controller": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -1867,23 +2009,24 @@
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "peer": true
     },
     "dynamoose-logger": {
-      "version": "3.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/dynamoose-logger/-/dynamoose-logger-3.0.0-beta.6.tgz",
-      "integrity": "sha512-VWumjBazD+CTi+hmduD99T8s4+lf1vWksEgSPfcUVaZxOuEKuFb1cN9f8cnuAGD5Y0Mz+jwJlMwlB4KqUK42Vg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/dynamoose-logger/-/dynamoose-logger-3.1.0.tgz",
+      "integrity": "sha512-TNo6Eknj9Sgl5Ek9yTw0IycuXAHSqqHZ4ViJKlOz8uL96CJBURnWZ1Bt0R6QyuFWZbfz9TfLbNfv+EYBaUxp6A==",
       "dev": true,
       "requires": {
-        "dynamoose-utils": "^3.0.0-beta.6",
+        "dynamoose-utils": "^3.1.0",
         "js-object-utilities": "^2.1.0",
         "uuid": "^8.3.2"
       }
     },
     "dynamoose-utils": {
-      "version": "3.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.0.0-beta.6.tgz",
-      "integrity": "sha512-8DPvCUff7bqC2tM6B4uvJf/Qik0cKcDCJysvEsuJy1OdhBMFM7+UgtO6ZbmlZqOQCCxpycu0Ix16uHH1sRX+Zw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.1.0.tgz",
+      "integrity": "sha512-HeSR4H9HvhQM2zb+4LuQlfQMHYCSn9aSsAyDArUlqfLn3cDCfrYN/HBMVTv8pNkqOakAB7MlYOW7ubDThbsvKQ==",
       "requires": {
         "js-object-utilities": "^2.1.0"
       }
@@ -1891,12 +2034,14 @@
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "peer": true
     },
     "fast-xml-parser": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "peer": true
     },
     "js-object-utilities": {
       "version": "2.1.0",
@@ -1907,6 +2052,7 @@
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "peer": true,
       "requires": {
         "obliterator": "^1.6.1"
       }
@@ -1914,12 +2060,14 @@
     "obliterator": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "peer": true
     },
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "peer": true
     },
     "uuid": {
       "version": "8.3.2",

--- a/packages/dynamoose/package.json
+++ b/packages/dynamoose/package.json
@@ -29,8 +29,8 @@
     "js-object-utilities": "^2.1.0"
   },
   "peerDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.142.0",
-    "@aws-sdk/util-dynamodb": "^3.142.0"
+    "@aws-sdk/client-dynamodb": "3.x",
+    "@aws-sdk/util-dynamodb": "3.x"
   },
   "devDependencies": {
     "dynamoose-logger": "^3.1.0"

--- a/packages/dynamoose/package.json
+++ b/packages/dynamoose/package.json
@@ -25,10 +25,12 @@
     "test:types": "tsc --project test/types/tsconfig.json"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.142.0",
-    "@aws-sdk/util-dynamodb": "^3.142.0",
     "dynamoose-utils": "^3.1.0",
     "js-object-utilities": "^2.1.0"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.142.0",
+    "@aws-sdk/util-dynamodb": "^3.142.0"
   },
   "devDependencies": {
     "dynamoose-logger": "^3.1.0"


### PR DESCRIPTION
### Summary:
I moved '@aws-sdk/client-dynamodb', '@aws-sdk/util-dynamodb' to peerDependecies.
On AWS Lambda, '@aws-sdk/*' modules is already embedded([Reference](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)).
Even though i exclude that, when i installed 'dynamoose', '@aws-sdk/client-dynamodb' is included to bundled package.



### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [x] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
