### PR TITLE
pendingTasks error handling 

### DIFF
--- a/packages/dynamoose/lib/Table/index.ts
+++ b/packages/dynamoose/lib/Table/index.ts
@@ -252,9 +252,6 @@ export class Table extends InternalPropertiesClass<TableInternalProperties> {
 					this.getInternalProperties(internalProperties).pendingTasks.forEach((task) => task.resolve());
 					this.getInternalProperties(internalProperties).pendingTasks = [];
 				} catch (error) {
-					this.getInternalProperties(internalProperties).ready = false;
-					this.getInternalProperties(internalProperties).setupFlowRunning = false;
-
 					this.getInternalProperties(internalProperties).pendingTasks.forEach((task) => task.reject(error));
 					this.getInternalProperties(internalProperties).pendingTasks = [];
 

--- a/packages/dynamoose/lib/Table/index.ts
+++ b/packages/dynamoose/lib/Table/index.ts
@@ -257,6 +257,8 @@ export class Table extends InternalPropertiesClass<TableInternalProperties> {
 
 					this.getInternalProperties(internalProperties).pendingTasks.forEach((task) => task.reject(error));
 					this.getInternalProperties(internalProperties).pendingTasks = [];
+
+					throw error;
 				}
 			}
 		});

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -2021,6 +2021,17 @@ describe("Model", () => {
 						expect(r.updatedAt).toBeWithinRange(date2 - 10, date2 + 10);
 					});
 				});
+
+				it("Should throw error if AWS throws error", async () => {
+					dynamoose.aws.ddb.set({
+						"createTable": () => ({
+							"promise": () => Promise.reject(new Error("AWS ERROR"))
+						})
+					});
+
+					const Model = dynamoose.model("Cat", {"id": String}, {"create": true});
+					await expect(Model.create({"id" : "cat"})).rejects.toThrow("AWS ERROR");
+				});
 			});
 		});
 	});


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:

when I put in the wrong AWS_SECRET_ACCESS_KEY, I get an error in the console but can't get out of the await promise.
so I checked the code and saw that there is no exception handling for `await setupFlowPromise` in `/lib/Table/index.ts`.

<img width="1661" alt="screenshot1" src="https://user-images.githubusercontent.com/125640661/235368451-e6478389-92e3-48df-94c6-b21ec86fe35a.png">

<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### General
```typescript
const dynamoose = require("dynamoose");

(async () => {
  console.log(1);
  const Cat = dynamoose.model("Cat", new dynamoose.Schema({ name: String }));
  try {
    console.log(2);
    await Cat.create({
      name: "cat",
    });
    console.log(3);
  } catch (error) {
    console.log(4);
  }
  console.log(5);
})();
```

#### Expectation

<img width="654" alt="screenshot2" src="https://user-images.githubusercontent.com/125640661/235368954-25f870f6-69f7-4757-b925-7d67a513e8c6.png">


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:




### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [ ] No
- [x] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [ ] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above

<!-- I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law. -->
