### PR TITLE
Fix global index deletion when projection type is INCLUDE

### DIFF
--- a/packages/dynamoose/lib/utils/dynamoose/index_changes.ts
+++ b/packages/dynamoose/lib/utils/dynamoose/index_changes.ts
@@ -50,8 +50,8 @@ const index_changes = async (table: Table, existingIndexes = []): Promise<(Model
 		});
 
 		return !(expectedIndexes.GlobalSecondaryIndexes || []).find((searchIndex) => obj.equals(
-			sanitizeIndex(obj.pick(cleanedIndex, identicalProperties) as unknown as IndexItem), 
-			sanitizeIndex(obj.pick(searchIndex as any, identicalProperties) as unknown as IndexItem)
+			sanitizeIndex(obj.pick(cleanedIndex, identicalProperties) as IndexItem), 
+			sanitizeIndex(obj.pick(searchIndex as any, identicalProperties) as IndexItem)
 		));
 	}).map((index) => ({"name": index.IndexName as string, "type": TableIndexChangeType.delete}));
 	output.push(...deleteIndexes);

--- a/packages/dynamoose/lib/utils/dynamoose/index_changes.ts
+++ b/packages/dynamoose/lib/utils/dynamoose/index_changes.ts
@@ -34,6 +34,13 @@ const index_changes = async (table: Table, existingIndexes = []): Promise<(Model
 		identicalProperties.pop();
 	}
 
+	const sanitizeIndex = (index: IndexItem) => {
+		if (Array.isArray(index.Projection.NonKeyAttributes)) { 
+			index.Projection.NonKeyAttributes.sort();
+		}
+		return index;
+	}
+
 	const deleteIndexes: ModelIndexDeleteChange[] = existingIndexes.filter((index) => {
 		const cleanedIndex = deep_copy(index);
 		obj.entries(cleanedIndex).forEach(([key, value]) => {
@@ -42,7 +49,10 @@ const index_changes = async (table: Table, existingIndexes = []): Promise<(Model
 			}
 		});
 
-		return !(expectedIndexes.GlobalSecondaryIndexes || []).find((searchIndex) => obj.equals(obj.pick(cleanedIndex, identicalProperties), obj.pick(searchIndex as any, identicalProperties)));
+		return !(expectedIndexes.GlobalSecondaryIndexes || []).find((searchIndex) => obj.equals(
+			sanitizeIndex(obj.pick(cleanedIndex, identicalProperties) as unknown as IndexItem), 
+			sanitizeIndex(obj.pick(searchIndex as any, identicalProperties) as unknown as IndexItem)
+		));
 	}).map((index) => ({"name": index.IndexName as string, "type": TableIndexChangeType.delete}));
 	output.push(...deleteIndexes);
 

--- a/packages/dynamoose/lib/utils/dynamoose/index_changes.ts
+++ b/packages/dynamoose/lib/utils/dynamoose/index_changes.ts
@@ -35,11 +35,11 @@ const index_changes = async (table: Table, existingIndexes = []): Promise<(Model
 	}
 
 	const sanitizeIndex = (index: IndexItem) => {
-		if (Array.isArray(index.Projection.NonKeyAttributes)) { 
+		if (Array.isArray(index.Projection.NonKeyAttributes)) {
 			index.Projection.NonKeyAttributes.sort();
 		}
 		return index;
-	}
+	};
 
 	const deleteIndexes: ModelIndexDeleteChange[] = existingIndexes.filter((index) => {
 		const cleanedIndex = deep_copy(index);
@@ -50,8 +50,8 @@ const index_changes = async (table: Table, existingIndexes = []): Promise<(Model
 		});
 
 		return !(expectedIndexes.GlobalSecondaryIndexes || []).find((searchIndex) => obj.equals(
-			sanitizeIndex(obj.pick(cleanedIndex, identicalProperties) as IndexItem), 
-			sanitizeIndex(obj.pick(searchIndex as any, identicalProperties) as IndexItem)
+			sanitizeIndex(obj.pick(cleanedIndex, identicalProperties) as any),
+			sanitizeIndex(obj.pick(searchIndex as any, identicalProperties) as any)
 		));
 	}).map((index) => ({"name": index.IndexName as string, "type": TableIndexChangeType.delete}));
 	output.push(...deleteIndexes);

--- a/packages/dynamoose/test/utils/dynamoose/index_changes.js
+++ b/packages/dynamoose/test/utils/dynamoose/index_changes.js
@@ -215,7 +215,88 @@ describe("utils.dynamoose.index_changes", () => {
 			],
 			"schema": {"id": String, "data": {"type": String, "index": {"name": "data-index-1", "type": "global", "project": true}}},
 			"output": []
-		}
+		},
+		{
+			"input": [], 
+			"schema": {"id": String, "data1": {"type": String, "index": {"type": "global", "project": ["data2"]}}, "data2": String, "data3": String}, 
+			"output": [{
+				"spec": {
+					"IndexName": "data1GlobalIndex",
+					"KeySchema": [
+						{
+							"AttributeName": "data1",
+							"KeyType": "HASH"
+						}
+					],
+					"Projection": {
+						"NonKeyAttributes": [ "data2" ],
+						"ProjectionType": "INCLUDE",
+					},
+					"ProvisionedThroughput": {
+						"ReadCapacityUnits": 1,
+						"WriteCapacityUnits": 1
+					}
+				},
+				"type": "add"
+			}]
+		},
+		{
+			"input": [
+				{
+					"IndexName": "data-index-1",
+					"KeySchema": [
+						{
+							"AttributeName": "data1",
+							"KeyType": "HASH"
+						}
+					],
+					"Projection": {
+						"NonKeyAttributes": [ "data2", "data3" ], // order not same as schema definition
+						"ProjectionType": "INCLUDE",
+					},
+					"IndexStatus": "ACTIVE",
+					"ProvisionedThroughput": {
+						"ReadCapacityUnits": 1,
+						"WriteCapacityUnits": 1
+					},
+					"IndexSizeBytes": 0,
+					"ItemCount": 0,
+					"IndexArn": "arn:aws:dynamodb:ddblocal:000000000000:table/User/index/data-index-1"
+				}
+			],
+			"schema": {"id": String, "data1": {"type": String, "index": {"name": "data-index-1", "type": "global", "project": ["data3", "data2"]}}, "data2": String, "data3": String},
+			"output": []
+		},
+		{
+			"input": [
+				{
+					"IndexName": "data-index-1",
+					"KeySchema": [
+						{
+							"AttributeName": "data1",
+							"KeyType": "HASH"
+						}
+					],
+					"Projection": {
+						"NonKeyAttributes": [ "data2" ],
+						"ProjectionType": "INCLUDE",
+					},
+					"IndexStatus": "ACTIVE",
+					"ProvisionedThroughput": {
+						"ReadCapacityUnits": 1,
+						"WriteCapacityUnits": 1
+					},
+					"IndexSizeBytes": 0,
+					"ItemCount": 0,
+					"IndexArn": "arn:aws:dynamodb:ddblocal:000000000000:table/User/index/data-index-1"
+				}
+			],
+			"schema": {"id": String, "data1": {"type": String, "index": {"name": "data-index-1", "type": "global", "project": ["data3", "data2"]}}, "data2": String, "data3": String},
+			"output": [{
+				"name": "data-index-1",
+				"type": "delete"
+			}]
+		},
 	];
 
 	tests.forEach((test) => {

--- a/packages/dynamoose/test/utils/dynamoose/index_changes.js
+++ b/packages/dynamoose/test/utils/dynamoose/index_changes.js
@@ -217,8 +217,8 @@ describe("utils.dynamoose.index_changes", () => {
 			"output": []
 		},
 		{
-			"input": [], 
-			"schema": {"id": String, "data1": {"type": String, "index": {"type": "global", "project": ["data2"]}}, "data2": String, "data3": String}, 
+			"input": [],
+			"schema": {"id": String, "data1": {"type": String, "index": {"type": "global", "project": ["data2"]}}, "data2": String, "data3": String},
 			"output": [{
 				"spec": {
 					"IndexName": "data1GlobalIndex",
@@ -229,8 +229,8 @@ describe("utils.dynamoose.index_changes", () => {
 						}
 					],
 					"Projection": {
-						"NonKeyAttributes": [ "data2" ],
-						"ProjectionType": "INCLUDE",
+						"NonKeyAttributes": ["data2"],
+						"ProjectionType": "INCLUDE"
 					},
 					"ProvisionedThroughput": {
 						"ReadCapacityUnits": 1,
@@ -251,8 +251,8 @@ describe("utils.dynamoose.index_changes", () => {
 						}
 					],
 					"Projection": {
-						"NonKeyAttributes": [ "data2", "data3" ], // order not same as schema definition
-						"ProjectionType": "INCLUDE",
+						"NonKeyAttributes": ["data2", "data3"], // order not same as schema definition
+						"ProjectionType": "INCLUDE"
 					},
 					"IndexStatus": "ACTIVE",
 					"ProvisionedThroughput": {
@@ -278,8 +278,8 @@ describe("utils.dynamoose.index_changes", () => {
 						}
 					],
 					"Projection": {
-						"NonKeyAttributes": [ "data2" ],
-						"ProjectionType": "INCLUDE",
+						"NonKeyAttributes": ["data2"],
+						"ProjectionType": "INCLUDE"
 					},
 					"IndexStatus": "ACTIVE",
 					"ProvisionedThroughput": {
@@ -296,7 +296,7 @@ describe("utils.dynamoose.index_changes", () => {
 				"name": "data-index-1",
 				"type": "delete"
 			}]
-		},
+		}
 	];
 
 	tests.forEach((test) => {


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->

### Summary:

Fixes issue where index is deleted when projection is set to `list of attributes` instead of `ALL`.

<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
const schema = new dynamoose.Schema(
    {
      id: {
        type: String,
        required: true,
        hashKey: true,
      },
      group: {
        type: String,
        required: true,
        index: {
            name: 'group-gsi',
            type: 'global',
            project: ['data1', 'data3', 'data2'],
        }
     },
     data1: String,
     data2: String,
     data3: String
);
```

#### Model
```
dynamoose.model('TableName', schema, {
  create: true,
  update: true,
});
```

<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #1603

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
