### PR TITLE
[batchGet] Use original item when comparing keys

### DIFF
--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -479,11 +479,17 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 			});
 			return (await Promise.all(keyObjects)).reduce((result, key) => {
 				const keyProperties = Object.keys(key);
-				const item = tmpResult.find((item) => keyProperties.every((keyProperty) => item[keyProperty] === key[keyProperty]));
+				const item = tmpResult.find((item) => {
+					const original = item.original();
+					return keyProperties.every((keyProperty) => original[keyProperty] === key[keyProperty]);
+				});
 				if (item) {
 					result.push(item);
 				} else {
-					const item = tmpResultUnprocessed.find((item) => keyProperties.every((keyProperty) => item[keyProperty] === key[keyProperty]));
+					const item = tmpResultUnprocessed.find((item) => {
+						const original = item.original();
+						return keyProperties.every((keyProperty) => original[keyProperty] === key[keyProperty]);
+					});
 					if (item) {
 						result.unprocessedKeys.push(item);
 					}


### PR DESCRIPTION
### Summary:

When using `batchGet`, it prepares the response by searching the items from a temp result by comparing their keys. Problem is that if these items have any transformation on their keys, they will never be found because the original keys are used in the search, always resulting in an empty response.

<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue: 
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #1442 

<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:

I've opted to put the original object in a temporary variable inside `find` to avoid multiple calls to `item.original()`. Alternatively we could one line with residual performance impact:

```javascript
const item = tmpResult.find((item) => keyProperties.every((keyProperty) => item.original()[keyProperty] === key[keyProperty]));
```

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
