### PR TITLE
update ttl to undefined if the set value is not a number

### DIFF
--- a/packages/dynamoose/lib/Table/index.ts
+++ b/packages/dynamoose/lib/Table/index.ts
@@ -276,7 +276,10 @@ export class Table extends InternalPropertiesClass<TableInternalProperties> {
 							"storage": "seconds"
 						}
 					},
-					"default": (): Date => new Date(Date.now() + (options.expires as TableExpiresSettings).ttl)
+					"default": (): Date | undefined => {
+						const ttl: number | undefined = (options.expires as TableExpiresSettings).ttl;
+						return typeof ttl === "number" ? new Date(Date.now() + ttl) : undefined;
+					}
 				};
 			});
 		}

--- a/packages/dynamoose/test/Item.js
+++ b/packages/dynamoose/test/Item.js
@@ -779,6 +779,20 @@ describe("Item", () => {
 					expect(parseInt(putParams[0].Item.ttl.N)).toBeWithinRange(expectedTTL - 1000, expectedTTL + 1000);
 				});
 
+				it("Should save with correct object with expires set to object with no ttl", async () => {
+					putItemFunction = () => Promise.resolve();
+					User = dynamoose.model("User", new Schema({"id": Number, "name": String}));
+					new dynamoose.Table("User", [User], {"create": false, "waitForActive": false, "expires": {"attribute": "ttl"}});
+					user = new User({"id": 1, "name": "Charlie"});
+					await callType.func(user).bind(user)();
+					expect(putParams[0].TableName).toEqual("User");
+					expect(putParams[0].Item).toBeInstanceOf(Object);
+					expect(putParams[0].Item.id).toEqual({"N": "1"});
+					expect(putParams[0].Item.name).toEqual({"S": "Charlie"});
+					const expectedTTL = undefined;
+					expect(putParams[0].Item.ttl).toEqual(expectedTTL);
+				});
+
 				it("Should save with correct object with timestamps set to true", async () => {
 					putItemFunction = () => Promise.resolve();
 					User = dynamoose.model("User", new Schema({"id": Number, "name": String}, {"timestamps": true}), {"create": false, "waitForActive": false});


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:

This fixes the issue where item updates fail with error `Special numeric value NaN is not allowed`, when ttl value is not set in the table schema.

A type check for the ttl value is introduced to allow a value to be inserted only when it is `number`

<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
{
  expires: {
    attribute: 'deletedAt',
  },
}
```

#### Model
```
dynamoose.model('TableName', schema, {
  create: true,
  update: true,
});
```

#### General
```
await TableName.create({ id: 1, name: 'Hello' });
// expected: a ttl is not inserted

await TableName.create({ id: 1, name: 'Hello', deletedAt: Date.now()/1000 + 3600 });
// expected: given ttl seconds are inserted
```


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
closes: #1518 

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
