### PR TITLE
Fixed syntax error in configuration docs

### DIFF
--- a/docs/docs_src/getting_started/Configure.mdx
+++ b/docs/docs_src/getting_started/Configure.mdx
@@ -22,13 +22,13 @@ The following code will create a new DynamoDB instance with the specific configu
 
 ```js
 // Create new DynamoDB instance
-const ddb = new dynamoose.aws.ddb.DynamoDB({
+const ddb = new dynamoose.aws.ddb.DynamoDB([{
 	"credentials": {
 		"accessKeyId": "AKID",
 		"secretAccessKey": "SECRET"
 	},
 	"region": "us-east-1"
-});
+}]);
 
 // Set DynamoDB instance to the Dynamoose DDB instance
 dynamoose.aws.ddb.set(ddb);


### PR DESCRIPTION
### Summary:
dynamoose.aws.ddb.DynamoDB() accepts array of objects rather that object


### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [x] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [ ] I have read through and followed the Contributing Guidelines
- [ ] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [ ] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [ ] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
