### PR TITLE
fix: tableName bug in Model.transaction method when using prefix/suffix

### DIFF
--- a/packages/dynamoose/lib/Table/index.ts
+++ b/packages/dynamoose/lib/Table/index.ts
@@ -130,9 +130,10 @@ export class Table extends InternalPropertiesClass<TableInternalProperties> {
 		}
 
 		const storedOptions = utils.combine_objects(options, customDefaults.get(), originalDefaults) as TableOptions;
+		const tableName = `${storedOptions.prefix}${name}${storedOptions.suffix}`;
 		this.setInternalProperties(internalProperties, {
 			"options": storedOptions,
-			"name": `${storedOptions.prefix}${name}${storedOptions.suffix}`,
+			"name": tableName,
 			"originalName": name, // This represents the name before prefix and suffix were added
 
 			instance,
@@ -162,7 +163,7 @@ export class Table extends InternalPropertiesClass<TableInternalProperties> {
 				model.Model.setInternalProperties(internalProperties, {
 					...model.Model.getInternalProperties(internalProperties),
 					"_table": this,
-					"tableName": name
+					"tableName": tableName
 				});
 				return model;
 			}),

--- a/packages/dynamoose/test/Transaction.js
+++ b/packages/dynamoose/test/Transaction.js
@@ -154,7 +154,42 @@ describe("Transaction", () => {
 				});
 			});
 
-			it("Should send correct parameters to AWS by using the Model.transaction methods", async () => {
+			it("Should send correct parameters to AWS with Prefix and Suffix", async () => {
+				let transactParams = {};
+				dynamoose.aws.ddb.set({
+					"transactGetItems": (params) => {
+						transactParams = params;
+						return Promise.resolve({});
+					}
+				});
+
+				const User = dynamoose.model("User", {"id": Number, "name": String});
+				const Credit = dynamoose.model("Credit", {"id": Number, "name": String});
+				new dynamoose.Table("Table", [User, Credit], {"prefix": "MyApp_", "suffix": "_Table"});
+				await callType.func(dynamoose.transaction)([{"Get": {"Key": {"id": {"N": "1"}}, "TableName": "MyApp_Table_Table"}}, {"Get": {"Key": {"id": {"N": "2"}}, "TableName": "MyApp_Table_Table"}}]);
+				expect(transactParams).toEqual({
+					"TransactItems": [
+						{
+							"Get": {
+								"Key": {
+									"id": {"N": "1"}
+								},
+								"TableName": "MyApp_Table_Table"
+							}
+						},
+						{
+							"Get": {
+								"Key": {
+									"id": {"N": "2"}
+								},
+								"TableName": "MyApp_Table_Table"
+							}
+						}
+					]
+				});
+			});
+
+			it("Should send correct parameters to AWS by using the Model.transaction methods with Prefix", async () => {
 				let transactParams = {};
 				dynamoose.aws.ddb.set({
 					"transactGetItems": (params) => {
@@ -263,7 +298,7 @@ describe("Transaction", () => {
 				});
 			});
 
-			it("Should send correct parameters to AWS for put items by using the Model.transaction methods", async () => {
+			it("Should send correct parameters to AWS for put items by using the Model.transaction methods with Suffix", async () => {
 				let transactParams = {};
 				dynamoose.aws.ddb.set({
 					"transactWriteItems": (params) => {


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->

### Summary:

I want to use a different suffix as the stage, but doing so would cause an error in the transaction method in the following code.
```ts
		tables.forEach((table, index) => {
			if (!table) {
				throw new Error.InvalidParameter(`Table "${uniqueTableNames[index]}" not found. Please register the table with dynamoose before using it in transactions.`);
			}
		});
```

https://dynamoosejs.com/guide/Transaction also shows an example of using the [Model.transaction method](https://dynamoosejs.com/guide/Model#modeltransaction).
The test code consists only of RAW objects, so it doesn't seem to have detected this bug situation.

<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:

I'll show you the code from [nestjs-dynamoose](https://github.com/hardyscc/nestjs-dynamoose), but I believe you can guess it well.

#### Schema
```
export const UserSchema = new Schema({
  id: {
    type: String,
    hashKey: true,
  },
  name: {
    type: String,
  },
  email: {
    type: String,
  },
});
```

#### Model
```
export interface UserKey {
  id: string;
}

export interface User extends UserKey {
  name: string;
  email?: string;
}
```

#### General
```
@Module({
  imports: [
    DynamooseModule.forFeature([{
      name: 'User',
      schema: UserSchema,
      options: {
        tableName: 'user',
        suffix: process.env.stage === 'prod' ? '_prod' : '_dev'
      },
    }]),
  ],
  providers: [
    UserService,
    ...
  ],
})
export class UserModule {}
```


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->

I looked through the issue items, but it doesn't seem to exist yet.
If I couldn't find it, please provide a link.

<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:




### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [x] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [x] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
