### PR TITLE
fix: query perf degradation from `deep_copy` util

### DIFF
--- a/packages/dynamoose/lib/utils/deep_copy.ts
+++ b/packages/dynamoose/lib/utils/deep_copy.ts
@@ -66,7 +66,7 @@ export default function deep_copy<T> (obj: T, refs = new Set()): T {
 					refs.add(value);
 				}
 
-				copy[attr] = deep_copy(obj[attr], refs);
+				copy[attr] = deep_copy(value, refs);
 			}
 		}
 		return copy;

--- a/packages/dynamoose/lib/utils/deep_copy.ts
+++ b/packages/dynamoose/lib/utils/deep_copy.ts
@@ -1,6 +1,4 @@
-import * as objectUtils from "js-object-utilities";
-
-export default function deep_copy<T> (obj: T): T {
+export default function deep_copy<T> (obj: T, refs = new Set()): T {
 	let copy: any;
 
 	// Handle Date
@@ -12,7 +10,7 @@ export default function deep_copy<T> (obj: T): T {
 
 	// Handle Array
 	if (obj instanceof Array) {
-		copy = obj.map((i) => deep_copy(i));
+		copy = obj.map((i) => deep_copy(i, refs));
 		return copy;
 	}
 
@@ -47,14 +45,28 @@ export default function deep_copy<T> (obj: T): T {
 
 	// Handle Object
 	if (obj instanceof Object) {
+		refs.add(obj);
+
 		if (obj.constructor !== Object) {
 			copy = Object.assign(Object.create(Object.getPrototypeOf(obj)), obj);
 		} else {
 			copy = {};
 		}
+
 		for (const attr in obj) {
-			if (Object.prototype.hasOwnProperty.call(obj, attr) && !objectUtils.isCircular(obj as any, attr)) {
-				copy[attr] = deep_copy(obj[attr]);
+			if (Object.prototype.hasOwnProperty.call(obj, attr)) {
+				const value = obj[attr];
+				const isObjValue = typeof value === "object" && !Array.isArray(value) && value !== null;
+
+				if (isObjValue) {
+					const isCircular = refs.has(value);
+					// Omit circular property from copy
+					if (isCircular) continue;
+
+					refs.add(value);
+				}
+
+				copy[attr] = deep_copy(obj[attr], refs);
 			}
 		}
 		return copy;

--- a/packages/dynamoose/test/utils/deep_copy.js
+++ b/packages/dynamoose/test/utils/deep_copy.js
@@ -69,6 +69,14 @@ describe("utils.deep_copy", () => {
 		expect(copy).toStrictEqual({"a": 1, "b": "test", "c": {"d": 100, "e": 200}});
 	});
 
+	it("Should return a deep copy of the passed object ignoring circular references", () => {
+		const original = {"a": 1, "b": "test", "c": {"d": 100, "e": 200, "f": {"g": 300}}};
+		original.self = original;
+		original.c.f.c = original.c;
+		const copy = utils.deep_copy(original);
+		expect(copy).toStrictEqual({"a": 1, "b": "test", "c": {"d": 100, "e": 200, "f": {"g": 300}}});
+	});
+
 	it("Should return a deep copy of the passed class instances", () => {
 		class PersonWrapper {
 			constructor (name, age) {

--- a/packages/dynamoose/test/utils/deep_copy.js
+++ b/packages/dynamoose/test/utils/deep_copy.js
@@ -72,6 +72,7 @@ describe("utils.deep_copy", () => {
 	it("Should return a deep copy of the passed object ignoring circular references", () => {
 		const original = {"a": 1, "b": "test", "c": {"d": 100, "e": 200, "f": {"g": 300}}};
 		original.self = original;
+		original.c.c = original.c;
 		original.c.f.c = original.c;
 		const copy = utils.deep_copy(original);
 		expect(copy).toStrictEqual({"a": 1, "b": "test", "c": {"d": 100, "e": 200, "f": {"g": 300}}});


### PR DESCRIPTION
### Summary:

I believe this fixes #1260.

[See this comment for context & details](https://github.com/dynamoose/dynamoose/issues/1260#issuecomment-2053897337)

### GitHub linked issue:

#1260

### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #---- @---)
- [x] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
