### PR TITLE
feat: add `undefined` to `Model.get` return type

### DIFF
--- a/docs/docs_src/getting_started/TypeScript.md
+++ b/docs/docs_src/getting_started/TypeScript.md
@@ -16,6 +16,8 @@ In order to get started using Dynamoose in your TypeScript project, simply [inst
 
 There is no need to install any additional `@types` package in order to use Dynamoose with TypeScript since the typings are included with the Dynamoose package.
 
+We highly recommend enabling `strict: true` in your [tsconfig.json](https://www.typescriptlang.org/tsconfig#strict), as some typings will not work correctly unless this option is enabled.
+
 After that, so long as you have TypeScript already setup on your project and text editor you should be ready to start using Dynamoose with TypeScript.
 
 ## FAQ

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -1004,15 +1004,15 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 	}
 
 	// Get
-	get (key: InputKey): Promise<T>;
-	get (key: InputKey, callback: CallbackType<T, any>): void;
+	get (key: InputKey): Promise<T | undefined>;
+	get (key: InputKey, callback: CallbackType<T | undefined, any>): void;
 	get (key: InputKey, settings: ModelGetSettings & {return: "request"}): Promise<DynamoDB.GetItemInput>;
 	get (key: InputKey, settings: ModelGetSettings & {return: "request"}, callback: CallbackType<DynamoDB.GetItemInput, any>): void;
-	get (key: InputKey, settings: ModelGetSettings): Promise<T>;
-	get (key: InputKey, settings: ModelGetSettings, callback: CallbackType<T, any>): void;
-	get (key: InputKey, settings: ModelGetSettings & {return: "item"}): Promise<T>;
-	get (key: InputKey, settings: ModelGetSettings & {return: "item"}, callback: CallbackType<T, any>): void;
-	get (key: InputKey, settings?: ModelGetSettings | CallbackType<T, any> | CallbackType<DynamoDB.GetItemInput, any>, callback?: CallbackType<T, any> | CallbackType<DynamoDB.GetItemInput, any>): void | Promise<DynamoDB.GetItemInput> | Promise<T> {
+	get (key: InputKey, settings: ModelGetSettings): Promise<T | undefined>;
+	get (key: InputKey, settings: ModelGetSettings, callback: CallbackType<T | undefined, any>): void;
+	get (key: InputKey, settings: ModelGetSettings & {return: "item"}): Promise<T | undefined>;
+	get (key: InputKey, settings: ModelGetSettings & {return: "item"}, callback: CallbackType<T | undefined, any>): void;
+	get (key: InputKey, settings?: ModelGetSettings | CallbackType<T | undefined, any> | CallbackType<DynamoDB.GetItemInput, any>, callback?: CallbackType<T | undefined, any> | CallbackType<DynamoDB.GetItemInput, any>): void | Promise<DynamoDB.GetItemInput> | Promise<T | undefined> {
 		if (typeof settings === "function") {
 			callback = settings;
 			settings = {"return": "item"};

--- a/packages/dynamoose/test/types/Model.ts
+++ b/packages/dynamoose/test/types/Model.ts
@@ -72,6 +72,8 @@ const shouldFailWithInvalidUpdateTransaction = model.transaction.update(0);
 // @ts-expect-error
 const shouldFailWithInvalidConditionTransaction = model.transaction.condition(0, []);
 
+
+
 // Typed Models
 export class User extends Item {
 	id: string;

--- a/packages/dynamoose/test/types/Model.ts
+++ b/packages/dynamoose/test/types/Model.ts
@@ -72,8 +72,6 @@ const shouldFailWithInvalidUpdateTransaction = model.transaction.update(0);
 // @ts-expect-error
 const shouldFailWithInvalidConditionTransaction = model.transaction.condition(0, []);
 
-
-
 // Typed Models
 export class User extends Item {
 	id: string;

--- a/packages/dynamoose/test/types/Model.ts
+++ b/packages/dynamoose/test/types/Model.ts
@@ -74,9 +74,9 @@ const shouldFailWithInvalidConditionTransaction = model.transaction.condition(0,
 
 // Typed Models
 export class User extends Item {
-	id: string;
-	name: string;
-	age: number;
+	id!: string;
+	name!: string;
+	age!: number;
 }
 const userSchema = new dynamoose.Schema({
 	"id": String,
@@ -108,5 +108,5 @@ UserTypedModel.update({"id": "foo"}, {
 });
 
 UserTypedModel.update({"id": "foo"}, {
-	"$REMOVE":{"age":null}
+	"$REMOVE":{"age":undefined}
 });

--- a/packages/dynamoose/test/types/Schema.ts
+++ b/packages/dynamoose/test/types/Schema.ts
@@ -107,7 +107,7 @@ const shouldSucceedWithAsyncSetMethodSchema = new dynamoose.Schema({
 const shouldSucceedWithSetMethodSecondArgSchema = new dynamoose.Schema({
 	"id": {
 		"type": String,
-		"set": (value, oldValue) => oldValue
+		"set": (value, oldValue) => oldValue ? oldValue : value
 	}
 });
 const shouldSucceedWithAsyncValidateMethodSchema = new dynamoose.Schema({

--- a/packages/dynamoose/test/types/model/Get.ts
+++ b/packages/dynamoose/test/types/model/Get.ts
@@ -1,0 +1,12 @@
+/* eslint @typescript-eslint/no-unused-vars: 0 */
+
+import {UserTypedModel} from "../Model";
+
+const shouldGetSuccessfully = await UserTypedModel.get("1");
+const user = shouldGetSuccessfully;
+// @ts-expect-error
+const shouldFailImmediatePropertyAccess = user.id;
+
+if (user) {
+	const shouldPassPropertyAccessAfterNullishCheck = user.id;
+}

--- a/packages/dynamoose/test/types/model/Query.ts
+++ b/packages/dynamoose/test/types/model/Query.ts
@@ -23,9 +23,12 @@ let isAssignableToQuery : Query<User>;
 isAssignableToQuery = UserTypedModel.query("name").eq("Will").limit(5);
 
 // query.startAt(key)
-async function queryStartAt (): Promise<Query<User>> {
+async function queryStartAt (): Promise<Query<User> | undefined> {
 	const response = await UserTypedModel.query("name").eq("Will").exec();
-	return UserTypedModel.query("name").eq("Will").startAt(response.lastKey);
+
+	if (response.lastKey) {
+		return UserTypedModel.query("name").eq("Will").startAt(response.lastKey);
+	}
 }
 
 // query.attributes(attributes)

--- a/packages/dynamoose/test/types/model/Scan.ts
+++ b/packages/dynamoose/test/types/model/Scan.ts
@@ -25,9 +25,11 @@ let isAssignableToScan : Scan<User>;
 isAssignableToScan = UserTypedModel.scan().limit(5);
 
 // scan.startAt(key)
-async function scanStartAt (): Promise<Scan<User>> {
+async function scanStartAt (): Promise<Scan<User> | undefined> {
 	const response = await UserTypedModel.scan().exec();
-	return UserTypedModel.scan().startAt(response.lastKey);
+	if (response.lastKey) {
+		return UserTypedModel.scan().startAt(response.lastKey);
+	}
 }
 
 // scan.attributes(attributes)

--- a/packages/dynamoose/test/types/tsconfig.json
+++ b/packages/dynamoose/test/types/tsconfig.json
@@ -6,6 +6,6 @@
 		"target": "es2017",
 		"noEmit": true,
 		"strict": true
-	},
+},
 	"include": ["./**/*"]
 }

--- a/packages/dynamoose/test/types/tsconfig.json
+++ b/packages/dynamoose/test/types/tsconfig.json
@@ -4,7 +4,8 @@
 		"moduleResolution": "node",
 		"lib": ["es2015"],
 		"target": "es2017",
-		"noEmit": true
+		"noEmit": true,
+		"strict": true
 	},
 	"include": ["./**/*"]
 }


### PR DESCRIPTION
### Summary

Fixes #1622

### Code sample

#### Before
```ts
const user = UserModel.get('id')
const id = user.id // ✅ Works, but can lead to runtime errors
```

#### After
```ts
const user = UserModel.get('id')
const id = user.id // ❌ `id` is potentially undefined

if (user) {
  const id = user.id // ✅ Safe
}
```


### GitHub linked issue

#1622

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [x] 🚨 YES 🚨 (Definitely will break in userland)
- [ ] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
