### PR TITLE
Update importPackage.ts to Fix #1617

### DIFF
--- a/packages/dynamoose/lib/utils/importPackage.ts
+++ b/packages/dynamoose/lib/utils/importPackage.ts
@@ -4,7 +4,7 @@ export default async (name: string): Promise<any> => {
 	if (undefinedPackages.includes(name)) {
 		throw new Error("Package can not be found.");
 	} else {
-		const pkg = await import(name);
+		const pkg = await import(`${name}`);
 		return pkg;
 	}
 };


### PR DESCRIPTION
### Summary:

Fix #1617 

Details: 
I was getting this error in nextjs.
After adding configuration option in the issue, the code was working fine but the warning was still showing up.
To get rid of that warning, I followed through this stackoverflow post: https://stackoverflow.com/questions/42908116/webpack-critical-dependency-the-request-of-a-dependency-is-an-expression


![image](https://github.com/user-attachments/assets/1d33aa62-3731-4ded-8e04-453062c3c981)




<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
#---- Closes #1617


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:




### Type (select 1):
- [x] Bug fix


### Is this a breaking change? (select 1):
- [x] No


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes



### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [ ] I have filled out all fields above
