### PR TITLE
Remove stale cron job for PRs

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -14,9 +14,9 @@ jobs:
           stale-issue-message: 'This issue is stale because it has been open 7 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
           stale-issue-label: 'status:stale'
           exempt-issue-labels: 'status:not-stale,status:todo,status:triage,type:discussion'
-          stale-pr-message: 'This pull request is stale because it has been open 7 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
-          stale-pr-label: 'status:stale'
-          exempt-pr-labels: 'status:not-stale,status:todo,status:triage,type:discussion'
+          # stale-pr-message: 'This pull request is stale because it has been open 7 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
+          # stale-pr-label: 'status:stale'
+          # exempt-pr-labels: 'status:not-stale,status:todo,status:triage,type:discussion'
           days-before-stale: 7
           days-before-close: 3
   nightly-merge:


### PR DESCRIPTION
### Summary:

Remove stale cron job for PRs


### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [x] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
