### PR TITLE
Correct the type of default and await the value

### DIFF
--- a/packages/dynamoose/lib/Schema.ts
+++ b/packages/dynamoose/lib/Schema.ts
@@ -484,7 +484,7 @@ interface AttributeDefinition {
 	 * }
 	 * ```
 	 */
-	default?: ValueType | (() => ValueType);
+	default?: ValueType | Promise<ValueType> | (() => ValueType | Promise<ValueType>);
 	/**
 	 * You can set this property to always use the `default` value, even if a value is already set. This can be used for data that will be used as sort or secondary indexes. The default for this property is false.
 	 *
@@ -1394,7 +1394,7 @@ export class Schema extends InternalPropertiesClass<SchemaInternalProperties> {
 	async defaultCheck (key: string, value: ValueType, settings: any): Promise<ValueType | void> {
 		const isValueUndefined = typeof value === "undefined" || value === null;
 		if (settings.defaults && isValueUndefined || settings.forceDefault && this.getAttributeSettingValue("forceDefault", key)) {
-			const defaultValueRaw = this.getAttributeSettingValue("default", key);
+			const defaultValueRaw = await this.getAttributeSettingValue("default", key);
 
 			let hasMultipleTypes: boolean;
 			try {

--- a/packages/dynamoose/test/Schema.js
+++ b/packages/dynamoose/test/Schema.js
@@ -1331,7 +1331,6 @@ describe("Schema", () => {
 			it(test.name, async () => {
 				const schema = new dynamoose.Schema(test.schema);
 				const output = await schema.getAttributeSettingValue(...test.input);
-				schema.defaultCheck;
 				if (typeof output !== "function") {
 					expect(output).toEqual(test.output);
 				} else {

--- a/packages/dynamoose/test/Schema.js
+++ b/packages/dynamoose/test/Schema.js
@@ -1331,6 +1331,56 @@ describe("Schema", () => {
 			it(test.name, async () => {
 				const schema = new dynamoose.Schema(test.schema);
 				const output = await schema.getAttributeSettingValue(...test.input);
+				schema.defaultCheck
+				if (typeof output !== "function") {
+					expect(output).toEqual(test.output);
+				} else {
+					expect(typeof output).toEqual(typeof test.output);
+					expect(output.toString()).toEqual(test.output.toString());
+					expect(await output()).toEqual(await test.output());
+				}
+			});
+		});
+	});
+
+	describe("defaultCheck", () => {
+		const tests = [
+			{
+				"name": "Should not return default if value is passed",
+				"input": ["id", "Hello World, Not"],
+				"schema": {"id": {"type": String, "default": "Hello World"}},
+				"output": undefined
+			},
+			{
+				"name": "Should return default as string",
+				"input": ["id"],
+				"schema": {"id": {"type": String, "default": "Hello World"}},
+				"output": "Hello World"
+			},
+			{
+				"name": "Should return default as string if default is a function",
+				"input": ["id"],
+				"schema": {"id": {"type": String, "default": () => "Hello World"}},
+				"output": "Hello World"
+			},
+			{
+				"name": "Should return default as Promise<string> if default is an async function returning a string",
+				"input": ["id"],
+				"schema": {"id": {"type": String, "default": async () => "Hello World"}},
+				"output": "Hello World"
+			},
+			{
+				"name": "Should return default as Promise<string> if default is an a Promise<string>",
+				"input": ["id"],
+				"schema": {"id": {"type": String, "default": async () => "Hello World"}},
+				"output": "Hello World"
+			}
+		];
+		tests.forEach((test) => {
+			it(test.name, async () => {
+				const schema = new dynamoose.Schema(test.schema);
+				const [key, value] = test.input;
+				const output = await schema.defaultCheck(key, value, { defaults: true });
 				if (typeof output !== "function") {
 					expect(output).toEqual(test.output);
 				} else {

--- a/packages/dynamoose/test/Schema.js
+++ b/packages/dynamoose/test/Schema.js
@@ -1331,7 +1331,7 @@ describe("Schema", () => {
 			it(test.name, async () => {
 				const schema = new dynamoose.Schema(test.schema);
 				const output = await schema.getAttributeSettingValue(...test.input);
-				schema.defaultCheck
+				schema.defaultCheck;
 				if (typeof output !== "function") {
 					expect(output).toEqual(test.output);
 				} else {
@@ -1380,7 +1380,7 @@ describe("Schema", () => {
 			it(test.name, async () => {
 				const schema = new dynamoose.Schema(test.schema);
 				const [key, value] = test.input;
-				const output = await schema.defaultCheck(key, value, { defaults: true });
+				const output = await schema.defaultCheck(key, value, {"defaults": true});
 				if (typeof output !== "function") {
 					expect(output).toEqual(test.output);
 				} else {

--- a/packages/dynamoose/test/Schema.js
+++ b/packages/dynamoose/test/Schema.js
@@ -1369,6 +1369,18 @@ describe("Schema", () => {
 				"output": "Hello World"
 			},
 			{
+				"name": "Should return default as Promise<T[0]> if type is a multi type and the default returns a array of elements",
+				"input": ["id"],
+				"schema": {"id": {"type": [String, Number], "default": async () => ["Hello World", 7]}},
+				"output": "Hello World"
+			},
+			{
+				"name": "Should return default as undefined if default returns a Promise<null | undefined>",
+				"input": ["id"],
+				"schema": {"id": {"type": [String, Number], "default": async () => null}},
+				"output": undefined
+			},
+			{
 				"name": "Should return default as Promise<string> if default is an a Promise<string>",
 				"input": ["id"],
 				"schema": {"id": {"type": String, "default": async () => "Hello World"}},


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
According to the [docs](https://github.com/dynamoose/dynamoose/blob/v4.0.3/packages/dynamoose/lib/Schema.ts#L460) for a schema default value
`You can also pass in async functions or a function that returns a promise to the default property and Dynamoose will take care of waiting for the promise to resolve before saving the object.`

This is not reflected in the types for `default`, additionally the value is not currently not awaited. This PR corrects the types and fixes the logic to match the documentation.



<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
{"id": {"type": String, "default": async () => "Hello World"}}
```
In the above code sample, with his PR the default value will now be "Hello World" (previously it would be undefined)




### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
