### PR TITLE
♻️ ref: Standardize the package.json keys

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -32,5 +32,62 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamoose/dynamoose.git"
+  },
+  "author": {
+    "name": "Charlie Fish",
+    "email": "fishcharlie.code@gmail.com",
+    "url": "https://charlie.fish"
+  },
+  "contributors": [
+    {
+      "name": "Brandon Goode"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/dynamoose/dynamoose/issues"
+  },
+  "keywords": [
+    "dynamodb",
+    "dynamo",
+    "mongoose",
+    "aws",
+    "amazon",
+    "document",
+    "model",
+    "schema",
+    "database",
+    "data",
+    "datastore",
+    "query",
+    "scan",
+    "nosql",
+    "db",
+    "nosql",
+    "store",
+    "document store",
+    "table",
+    "json",
+    "object",
+    "storage"
+  ],
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "funding": [
+    {
+      "type": "github-sponsors",
+      "url": "https://github.com/sponsors/fishcharlie"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/dynamoose"
+    }
+  ]
 }

--- a/packages/dynamoose-logger/package.json
+++ b/packages/dynamoose-logger/package.json
@@ -23,6 +23,44 @@
     "uuid": "^9.0.1"
   },
   "license": "Unlicense",
+  "contributors": [
+    {
+      "name": "Brandon Goode"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/dynamoose/dynamoose/issues"
+  },
+  "keywords": [
+    "dynamodb",
+    "dynamo",
+    "mongoose",
+    "aws",
+    "amazon",
+    "document",
+    "model",
+    "schema",
+    "database",
+    "data",
+    "datastore",
+    "query",
+    "scan",
+    "nosql",
+    "db",
+    "nosql",
+    "store",
+    "document store",
+    "table",
+    "json",
+    "object",
+    "storage"
+  ],
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "files": [
+    "dist"
+  ],
   "funding": [
     {
       "type": "github-sponsors",

--- a/packages/dynamoose-utils/package.json
+++ b/packages/dynamoose-utils/package.json
@@ -21,6 +21,44 @@
     "js-object-utilities": "^2.2.1"
   },
   "license": "Unlicense",
+  "contributors": [
+    {
+      "name": "Brandon Goode"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/dynamoose/dynamoose/issues"
+  },
+  "keywords": [
+    "dynamodb",
+    "dynamo",
+    "mongoose",
+    "aws",
+    "amazon",
+    "document",
+    "model",
+    "schema",
+    "database",
+    "data",
+    "datastore",
+    "query",
+    "scan",
+    "nosql",
+    "db",
+    "nosql",
+    "store",
+    "document store",
+    "table",
+    "json",
+    "object",
+    "storage"
+  ],
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "files": [
+    "dist"
+  ],
   "funding": [
     {
       "type": "github-sponsors",

--- a/packages/dynamoose/package.json
+++ b/packages/dynamoose/package.json
@@ -37,6 +37,41 @@
     "dynamoose-logger": "^4.0.4"
   },
   "license": "Unlicense",
+  "contributors": [
+    {
+      "name": "Brandon Goode"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/dynamoose/dynamoose/issues"
+  },
+  "keywords": [
+    "dynamodb",
+    "dynamo",
+    "mongoose",
+    "aws",
+    "amazon",
+    "document",
+    "model",
+    "schema",
+    "database",
+    "data",
+    "datastore",
+    "query",
+    "scan",
+    "nosql",
+    "db",
+    "nosql",
+    "store",
+    "document store",
+    "table",
+    "json",
+    "object",
+    "storage"
+  ],
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "funding": [
     {
       "type": "github-sponsors",

--- a/publish/package.json
+++ b/publish/package.json
@@ -11,5 +11,62 @@
     "openurl": "^1.1.1",
     "ora": "^6.1.2",
     "simple-git": "^3.11.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamoose/dynamoose.git"
+  },
+  "author": {
+    "name": "Charlie Fish",
+    "email": "fishcharlie.code@gmail.com",
+    "url": "https://charlie.fish"
+  },
+  "contributors": [
+    {
+      "name": "Brandon Goode"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/dynamoose/dynamoose/issues"
+  },
+  "keywords": [
+    "dynamodb",
+    "dynamo",
+    "mongoose",
+    "aws",
+    "amazon",
+    "document",
+    "model",
+    "schema",
+    "database",
+    "data",
+    "datastore",
+    "query",
+    "scan",
+    "nosql",
+    "db",
+    "nosql",
+    "store",
+    "document store",
+    "table",
+    "json",
+    "object",
+    "storage"
+  ],
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "funding": [
+    {
+      "type": "github-sponsors",
+      "url": "https://github.com/sponsors/fishcharlie"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/dynamoose"
+    }
+  ]
 }

--- a/utils/source-map-stacktrace-parser/package.json
+++ b/utils/source-map-stacktrace-parser/package.json
@@ -1,7 +1,64 @@
 {
-	"dependencies": {
-		"@actions/core": "^1.9.0",
-		"simple-git": "^3.11.0",
-		"source-map": "^0.7.4"
-	}
+  "dependencies": {
+    "@actions/core": "^1.9.0",
+    "simple-git": "^3.11.0",
+    "source-map": "^0.7.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dynamoose/dynamoose.git"
+  },
+  "author": {
+    "name": "Charlie Fish",
+    "email": "fishcharlie.code@gmail.com",
+    "url": "https://charlie.fish"
+  },
+  "contributors": [
+    {
+      "name": "Brandon Goode"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/dynamoose/dynamoose/issues"
+  },
+  "keywords": [
+    "dynamodb",
+    "dynamo",
+    "mongoose",
+    "aws",
+    "amazon",
+    "document",
+    "model",
+    "schema",
+    "database",
+    "data",
+    "datastore",
+    "query",
+    "scan",
+    "nosql",
+    "db",
+    "nosql",
+    "store",
+    "document store",
+    "table",
+    "json",
+    "object",
+    "storage"
+  ],
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "funding": [
+    {
+      "type": "github-sponsors",
+      "url": "https://github.com/sponsors/fishcharlie"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/dynamoose"
+    }
+  ]
 }


### PR DESCRIPTION
## PR Title: ♻️ ref: Standardize the package.json keys

### Description  
This PR adds missing root-level fields to all `packages/package.json` files to ensure consistency across the repo. These fields already exist in the root `package.json` but were missing in individual package files.

### Changes Made
- Added the following fields to all package `package.json` files:
  - `repository`
  - `contributors`
  - `contributors`
  - `bugs`
  - `keywords`
  - `engines`
  - `funding`