### PR TITLE
Fixing comparison with objects when returning in unprocessedItems

### DIFF
--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -559,7 +559,7 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 			const unprocessedArray = response.UnprocessedItems && response.UnprocessedItems[table.getInternalProperties(internalProperties).name] ? response.UnprocessedItems[this.getInternalProperties(internalProperties).table().getInternalProperties(internalProperties).name] : [];
 			const tmpResultUnprocessed = await Promise.all(unprocessedArray.map((item) => this.Item.fromDynamo(item.PutRequest.Item)));
 			return items.reduce((result: {unprocessedItems: ObjectType[]}, item) => {
-				const unprocessedItem = tmpResultUnprocessed.find((searchItem) => Object.keys(item).every((keyProperty) => searchItem[keyProperty] === item[keyProperty]));
+				const unprocessedItem = tmpResultUnprocessed.find((searchItem) => Object.keys(item).every((keyProperty) => utils.object.equals(searchItem[keyProperty], item[keyProperty])));
 				if (unprocessedItem) {
 					result.unprocessedItems.push(unprocessedItem);
 				}

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -2156,6 +2156,16 @@ describe("Model", () => {
 					});
 				});
 
+				it("Should return correct result from batchPut with UnprocessedItems with an array of objects property", async () => {
+					User = dynamoose.model("User", {"id": Number, "name": String, "externalIds": {"type": Array, "schema": [{"type": Object, "schema": {"id": Number}}]}});
+					new dynamoose.Table("User", [User]);
+					promiseFunction = () => Promise.resolve({"UnprocessedItems": {"User": [{"PutRequest": {"Item": {"id": {"N": "3"}, "name": {"S": "Tim"}, "externalIds": {"L": [{"M": {"id": {"N": "436229973"}}}]}}}}]}});
+					const result = await callType.func(User).bind(User)([{"id": 1, "name": "Charlie"}, {"id": 3, "name": "Tim", "externalIds":[{"id": 436229973}]}]);
+					expect(result).toEqual({
+						"unprocessedItems": [{"id": 3, "name": "Tim", "externalIds":[{"id": 436229973}]}]
+					});
+				});
+
 				it("Should throw error if error is returned from DynamoDB", () => {
 					promiseFunction = () => Promise.reject({"error": "ERROR"});
 


### PR DESCRIPTION
### Summary:

Fixes an issue where batchPut wouldn't return objects in unprocessedItems when item contains complex schema (array or object).


### GitHub linked issue:
Closes #1759

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
