### PR TITLE
Use DeepPartial in UpdatePartial to support nested object updates

### DIFF
--- a/packages/dynamoose/lib/General.ts
+++ b/packages/dynamoose/lib/General.ts
@@ -5,7 +5,7 @@ import {Model} from "./Model";
 export type CallbackType<R, E> = (error?: E | null, response?: R) => void;
 export type ObjectType = {[key: string]: any};
 export type FunctionType = (...args: any[]) => any;
-export type DeepPartial<T> = {[P in keyof T]?: DeepPartial<T[P]>};
+export type DeepPartial<T> = T extends object ? {[P in keyof T]?: DeepPartial<T[P]>} : T;
 
 // - Dynamoose
 

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -8,7 +8,7 @@ import Internal from "../Internal";
 import {Serializer, SerializerOptions} from "../Serializer";
 import {Condition, ConditionInitializer} from "../Condition";
 import {Scan, Query} from "../ItemRetriever";
-import {CallbackType, ObjectType, FunctionType, ItemArray, ModelType, KeyObject, InputKey} from "../General";
+import {CallbackType, ObjectType, FunctionType, ItemArray, ModelType, KeyObject, InputKey, DeepPartial} from "../General";
 import {PopulateItems} from "../Populate";
 import {AttributeMap} from "../Types";
 import * as DynamoDB from "@aws-sdk/client-dynamodb";
@@ -21,11 +21,11 @@ import returnModel from "../utils/dynamoose/returnModel";
 const {internalProperties} = Internal.General;
 
 type UpdatePartial<T> =
-  | Partial<T>
-  | { $SET: Partial<T> }
-  | { $ADD: Partial<T> }
+  | DeepPartial<T>
+  | { $SET: DeepPartial<T> }
+  | { $ADD: DeepPartial<T> }
   | { $REMOVE: { [K in keyof T]?: null } | string[] }
-  | { $DELETE: Partial<T> };
+  | { $DELETE: DeepPartial<T> };
 
 // Transactions
 type GetTransactionResult = Promise<GetTransactionInput>;
@@ -712,7 +712,7 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 			].reverse();
 
 			if (!updateObj) {
-				updateObj = utils.deep_copy(keyObj) as Partial<T>;
+				updateObj = utils.deep_copy(keyObj) as DeepPartial<T>;
 				Object.keys(await this.getInternalProperties(internalProperties).convertKeyToObject(keyObj)).forEach((key) => delete updateObj[key]);
 			}
 

--- a/packages/dynamoose/test/types/Model.ts
+++ b/packages/dynamoose/test/types/Model.ts
@@ -78,6 +78,10 @@ export class User extends Item {
 	name!: string;
 	age!: number;
 	friends!: string[];
+	settings!: {
+		theme: string;
+		notifications: boolean;
+	};
 }
 const userSchema = new dynamoose.Schema({
 	"id": String,
@@ -117,4 +121,11 @@ UserTypedModel.update({"id": "foo"}, {
 
 UserTypedModel.update({"id": "foo"}, {
 	"$REMOVE":{"age":null}
+});
+
+UserTypedModel.update({"id": "foo"}, {
+	"settings": {"theme": "dark"}
+});
+UserTypedModel.update({"id": "foo"}, {
+	"$SET": {"settings": {"notifications": false}}
 });


### PR DESCRIPTION
## Summary

`UpdatePartial<T>` uses a shallow `Partial<T>`, which forces TypeScript to require all nested properties when updating nested objects via `Model.update()`. This makes it impossible to partially update nested fields without type errors, even though DynamoDB and Dynamoose handle partial nested updates correctly at runtime.

**Root cause:** `Partial<T>` only makes top-level properties optional, so nested object types remain fully required.

**Fix:** Replace `Partial<T>` with the existing `DeepPartial<T>` utility type in the `UpdatePartial<T>` definition. Additionally, add a `T extends object` guard to `DeepPartial<T>` so that primitive types pass through unchanged. This prevents issues when the type parameter is `any` (untyped models).

### Changes

- **`packages/dynamoose/lib/General.ts`**: Add `T extends object` conditional guard to `DeepPartial<T>` so primitives are not recursively mapped
- **`packages/dynamoose/lib/Model/index.ts`**: Import `DeepPartial` and use it in `UpdatePartial<T>` in place of `Partial<T>` for `$SET`, `$ADD`, `$DELETE`, and the default partial branch
- **`packages/dynamoose/test/types/Model.ts`**: Add type tests for nested partial updates (both implicit and explicit `$SET`)

### Before (TypeScript error)
```ts
await UserModel.update({ id: "123" }, { settings: { theme: "dark" } });
// Error: Property 'notifications' is missing in type '{ theme: string; }'
```

### After (compiles correctly)
```ts
await UserModel.update({ id: "123" }, { settings: { theme: "dark" } });
// Works: only the provided nested properties are updated
```

## Test plan
- [x] `npm run build` passes
- [x] Type tests pass (`tsc --noEmit` on `test/types/tsconfig.json`)
- [x] All 710 runtime tests pass (`jest test/Model`)

Closes #1775