### PR TITLE
Merge nested object properties on update instead of replacing

### DIFF
--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -703,6 +703,7 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 		const table = this.getInternalProperties(internalProperties).table();
 		const {instance} = table.getInternalProperties(internalProperties);
 		let index = 0;
+		const isObject = (v: any): boolean => typeof v === "object" && v !== null && !Array.isArray(v);
 		const getUpdateExpressionObject: () => Promise<any> = async () => {
 			const updateTypes = [
 				{"name": "$SET", "operator": " = ", "objectFromSchemaSettings": {"validate": true, "enum": true, "forceDefault": true, "required": "nested", "modifiers": ["set"]}},
@@ -739,6 +740,27 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 					try {
 						dynamoType = schema.getAttributeType(subKey, subValue, {"unknownAttributeAllowed": true});
 					} catch (e) {} // eslint-disable-line no-empty
+
+					if (dynamoType === "M" && updateType.name === "$SET" && isObject(subValue)
+						&& schema.attributes().some((a) => a.startsWith(`${subKey}.`))) {
+						const schemaSettings = {...updateType.objectFromSchemaSettings, "type": "toDynamo", "customTypesDynamo": true, "saveUnknown": true, "mapAttributes": true, "required": false};
+						const processed = (await this.Item.objectFromSchema({[subKey]: subValue}, this, schemaSettings as any))[subKey];
+						accumulator.ExpressionAttributeNames[`#a${index}`] = subKey;
+						(function flatten (path: string, obj: ObjectType): void {
+							for (const [attr, val] of Object.entries(obj)) {
+								accumulator.ExpressionAttributeNames[`#a${index}`] = attr;
+								const k = `${path}.#a${index++}`;
+								if (isObject(val)) {
+									flatten(k, val);
+								} else {
+									accumulator.ExpressionAttributeValues[`:v${index}`] = val;
+									accumulator.UpdateExpression["SET"].push(`${k} = :v${index++}`);
+								}
+							}
+						})(`#a${index++}`, processed);
+						continue;
+					}
+
 					const attributeExists = schema.attributes().includes(subKey);
 					const dynamooseUndefined = type.UNDEFINED;
 					if (!updateType.attributeOnly && subValue !== dynamooseUndefined) {

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -3509,20 +3509,28 @@ describe("Model", () => {
 					return expect(callType.func(User).bind(User)({"id": 1}, {"friends": ["Bob"]})).resolves.toEqual();
 				});
 
-				it("Should throw error if trying to replace object without nested required property", () => {
+				it("Should merge nested object properties instead of replacing entire object", async () => {
 					updateItemFunction = () => Promise.resolve({});
 					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"name": String, "age": {"type": Number, "required": true}}}});
 					new dynamoose.Table("User", [User]);
 
-					return expect(callType.func(User).bind(User)({"id": 1}, {"data": {"name": "Charlie"}})).rejects.toEqual(new CustomError.ValidationError("data.age is a required property but has no value when trying to save item"));
+					await callType.func(User).bind(User)({"id": 1}, {"data": {"name": "Charlie"}});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toEqual("SET #a0.#a1 = :v2");
+					expect(updateItemParams.ExpressionAttributeNames).toEqual({"#a0": "data", "#a1": "name"});
+					expect(updateItemParams.ExpressionAttributeValues).toEqual({":v2": {"S": "Charlie"}});
 				});
 
-				it("Should throw error if trying to replace object with $SET without nested required property", () => {
+				it("Should merge nested object properties with $SET instead of replacing entire object", async () => {
 					updateItemFunction = () => Promise.resolve({});
 					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"name": String, "age": {"type": Number, "required": true}}}});
 					new dynamoose.Table("User", [User]);
 
-					return expect(callType.func(User).bind(User)({"id": 1}, {"$SET": {"data": {"name": "Charlie"}}})).rejects.toEqual(new CustomError.ValidationError("data.age is a required property but has no value when trying to save item"));
+					await callType.func(User).bind(User)({"id": 1}, {"$SET": {"data": {"name": "Charlie"}}});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toEqual("SET #a0.#a1 = :v2");
+					expect(updateItemParams.ExpressionAttributeNames).toEqual({"#a0": "data", "#a1": "name"});
+					expect(updateItemParams.ExpressionAttributeValues).toEqual({":v2": {"S": "Charlie"}});
 				});
 
 				it("Should use default value if deleting property", async () => {


### PR DESCRIPTION
## Summary

`Model.update()` replaces entire nested objects in DynamoDB instead of merging partial properties. When calling `update({ id }, { config: { featureA: false } })`, DynamoDB receives `SET #config = :v` which overwrites the entire `config` attribute, discarding any properties not included in the partial update.

**Root cause:** The update expression builder treats nested objects as single values, generating one `SET` expression for the whole attribute.

**Fix:** When a `$SET` operation targets a Map attribute (`"M"` type) that has a sub-schema, flatten the nested object into individual dot-notation `SET` expressions. This uses DynamoDB's native support for updating nested map attributes.

### Before
```
SET #a0 = :v0
ExpressionAttributeNames:  { "#a0": "config" }
ExpressionAttributeValues: { ":v0": { "M": { "featureA": { "BOOL": false } } } }
```
DynamoDB replaces the entire `config` map, removing any properties not in the update.

### After
```
SET #a0.#a1 = :v2
ExpressionAttributeNames:  { "#a0": "config", "#a1": "featureA" }
ExpressionAttributeValues: { ":v2": { "BOOL": false } }
```
DynamoDB updates only `config.featureA`, leaving other properties untouched.

### Changes

- **`packages/dynamoose/lib/Model/index.ts`**: Detect partial nested updates (Map type + sub-schema + plain object value) and recursively generate dot-notation SET expressions instead of a single whole-object SET
- **`packages/dynamoose/test/Model.js`**: Update 2 tests that expected the old "replace" behavior to verify the new "merge" behavior with correct dot-notation expressions

### Design decisions

- Only applies to `$SET` operations on Map attributes with a defined sub-schema
- Objects without a sub-schema (generic `{ type: Object }`) retain the current replace behavior
- Recursively flattens deeply nested objects to their leaf values
- Passes `required: false` to `objectFromSchema` so partial updates don't trigger validation errors for missing sibling properties

## Test plan
- [x] `npm run build` passes
- [x] Type tests pass (`tsc --noEmit`)
- [x] All 710 runtime tests pass (4 updated to match new merge behavior)

Closes #1776