### PR TITLE
fix: nested/partial Model.update, custom-type consistency, and array traversal

### DIFF
--- a/PENDING_CHANGELOG.md
+++ b/PENDING_CHANGELOG.md
@@ -2,10 +2,19 @@
 
 ---
 
+### 🚨 Breaking Changes 🚨
+
+- `Item.save` now applies custom type conversion to the item it resolves with, so custom typed attributes (such as `Date`) are returned in the same representation as `Model.get`. Previously `save` resolved with the underlying DynamoDB representation (for example a `number` for `Date` attributes) while `get` resolved with the custom type (a `Date` instance)
+
 ### Features
 
 - Added support for enabling and configuring DynamoDB Streams through Table options
+- Added a `merge` setting to `Model.update`. Passing `{"merge": true}` updates a nested object in place by writing each provided property to its own document path (`SET attr.sub = :v`), matching how a nested attribute update is expressed against DynamoDB directly, instead of replacing the whole attribute as a map. The default behavior is unchanged
 
 ### Bug Fixes
 
 - Fixed `deep_copy` dropping sibling properties that share the same object reference (e.g. a single `Date` used for both `createdAt` and `updatedAt`, or a single address used for both `billingAddress` and `shippingAddress`). Circular reference detection now tracks only the current ancestor path rather than every object ever visited, which also removes an infinite-recursion risk on self-referencing arrays and a shared-reference leak on class instances containing circular properties
+- Fixed `Model.update` corrupting arrays, Sets, and Buffers nested inside a map attribute. These values were traversed as if they were nested maps, which produced document paths keyed by array indices or byte offsets, and silently dropped Sets from the update entirely
+- Fixed `Item.attributesWithSchema` throwing `node.forEach is not a function` when an object was supplied for an attribute the schema defines as an array
+- Fixed `Model.update` rejecting partially specified nested attributes at the type level. Update bodies are now typed as `DeepPartial<T>`
+- Fixed the `save` callback being invoked a second time when the supplied callback itself threw an error

--- a/docs/docs_src/guide/Model.md
+++ b/docs/docs_src/guide/Model.md
@@ -320,6 +320,7 @@ You can also pass in a `settings` object parameter to define extra settings for 
 | return | What the function should return. Can be `item`, or `request`. In the event this is set to `request` the request Dynamoose will make to DynamoDB will be returned, and no request to DynamoDB will be made. | String | `item` |
 | condition | This is an optional instance of a Condition for the update. | [dynamoose.Condition](Condition.md) | `null`
 | returnValues | Set which documents to return after the update. This setting will be passed into the DynamoDB `ReturnValues` parameter. | String | `ALL_NEW`
+| merge | Set to `true` to update nested objects in place using document paths instead of replacing the whole attribute. See [Updating nested objects](#updating-nested-objects) below. | Boolean | `false`
 
 There are two different methods for specifying what you'd like to edit in the item. The first is you can just pass in the attribute name as the key, and the new value as the value. This will set the given attribute to the new value.
 
@@ -389,6 +390,40 @@ await User.update({"id": 1}, {"name": "Bob", "$ADD": {"age": 1}});
 ```
 
 The `validate` Schema attribute property will only be run on `$SET` values. This is due to the fact that Dynamoose is unaware of what the existing value is in the database for `$ADD` properties.
+
+### Updating nested objects
+
+By default, setting an object onto an attribute replaces that whole attribute as a map, so any properties you do not pass in are removed from the item.
+
+```js
+// schema: {"id": Number, "data": {"type": Object, "schema": {"name": String, "age": Number}}}
+// existing item: {"id": 1, "data": {"name": "Bob", "age": 30}}
+
+await User.update({"id": 1}, {"data": {"name": "Charlie"}});
+// UpdateExpression: SET #a0 = :v0
+// resulting item:   {"id": 1, "data": {"name": "Charlie"}}
+```
+
+Because the whole attribute is replaced, a nested `required` property that you do not pass in will fail validation.
+
+Passing `{"merge": true}` writes each provided property to its own document path instead, which updates those properties in place and leaves the rest of the map untouched. This is the same shape as a native DynamoDB nested attribute update (`SET data.#name = :value`).
+
+```js
+await User.update({"id": 1}, {"data": {"name": "Charlie"}}, {"merge": true});
+// UpdateExpression: SET #a0.#a1 = :v2
+// resulting item:   {"id": 1, "data": {"name": "Charlie", "age": 30}}
+```
+
+Merging works at any depth, and also applies to plain objects that have no nested schema (for example `saveUnknown` attributes).
+
+```js
+await User.update({"id": 1}, {"$SET": {"data": {"profile": {"name": "Charlie"}}}}, {"merge": true});
+// UpdateExpression: SET #a0.#a1.#a2 = :v3
+```
+
+Only plain objects are flattened. Arrays, Sets, Dates, and Buffers nested inside an object are always written as single leaf values.
+
+A nested document path can only be written when the parent map already exists on the item. If the attribute may not exist yet, leave `merge` unset so the whole map is written in one operation.
 
 ## model.delete(key[, settings][, callback])
 

--- a/packages/dynamoose/lib/General.ts
+++ b/packages/dynamoose/lib/General.ts
@@ -5,7 +5,7 @@ import {Model} from "./Model";
 export type CallbackType<R, E> = (error?: E | null, response?: R) => void;
 export type ObjectType = {[key: string]: any};
 export type FunctionType = (...args: any[]) => any;
-export type DeepPartial<T> = {[P in keyof T]?: DeepPartial<T[P]>};
+export type DeepPartial<T> = T extends object ? {[P in keyof T]?: DeepPartial<T[P]>} : T;
 
 // - Dynamoose
 

--- a/packages/dynamoose/lib/Item.ts
+++ b/packages/dynamoose/lib/Item.ts
@@ -482,8 +482,14 @@ export class Item extends InternalPropertiesClass<ItemInternalProperties> {
 			await promise;
 			this.getInternalProperties(internalProperties).storedInDynamo = true;
 
+			// First apply custom types conversion to the current item
+			await this.conformToSchema({"customTypesDynamo": true, "type": "fromDynamo", "typeCheck": false});
+
 			const returnItem = new (this.getInternalProperties(internalProperties).model).Item(savedItem as any);
 			returnItem.getInternalProperties(internalProperties).storedInDynamo = true;
+
+			// Apply custom types conversion to ensure consistent behavior with get
+			await returnItem.conformToSchema({"customTypesDynamo": true, "type": "fromDynamo"});
 
 			return returnItem;
 		})();
@@ -723,12 +729,14 @@ Item.objectFromSchema = async function (object: any, model: Model<Item>, setting
 			const isValueUndefined = typeof value === "undefined" || value === null;
 			if (!isValueUndefined) {
 				const typeDetails = utils.dynamoose.getValueTypeCheckResult(schema, value, key, settings, {typeIndexOptionMap}).matchedTypeDetails as DynamoDBTypeResult;
-				const {customType} = typeDetails;
-				const {"type": typeInfo} = typeDetails.isOfType(value as ValueType);
-				const isCorrectTypeAlready = typeInfo === (settings.type === "toDynamo" ? "underlying" : "main");
-				if (customType && customType.functions[settings.type] && !isCorrectTypeAlready) {
-					const customValue = customType.functions[settings.type](value);
-					utils.object.set(returnObject, key, customValue);
+				if (typeDetails) {
+					const {customType} = typeDetails;
+					const {"type": typeInfo} = typeDetails.isOfType(value as ValueType);
+					const isCorrectTypeAlready = typeInfo === (settings.type === "toDynamo" ? "underlying" : "main");
+					if (customType && customType.functions[settings.type] && !isCorrectTypeAlready) {
+						const customValue = customType.functions[settings.type](value);
+						utils.object.set(returnObject, key, customValue);
+					}
 				}
 			}
 		});

--- a/packages/dynamoose/lib/Item.ts
+++ b/packages/dynamoose/lib/Item.ts
@@ -478,26 +478,21 @@ export class Item extends InternalPropertiesClass<ItemInternalProperties> {
 			return ddb(table.getInternalProperties(internalProperties).instance, "putItem", putItemObj);
 		});
 
+		const resultPromise = (async (): Promise<Item> => {
+			await promise;
+			this.getInternalProperties(internalProperties).storedInDynamo = true;
+
+			const returnItem = new (this.getInternalProperties(internalProperties).model).Item(savedItem as any);
+			returnItem.getInternalProperties(internalProperties).storedInDynamo = true;
+
+			return returnItem;
+		})();
+
 		if (callback) {
 			const localCallback: CallbackType<Item, any> = callback as CallbackType<Item, any>;
-			promise.then(() => {
-				this.getInternalProperties(internalProperties).storedInDynamo = true;
-
-				const returnItem = new (this.getInternalProperties(internalProperties).model).Item(savedItem as any);
-				returnItem.getInternalProperties(internalProperties).storedInDynamo = true;
-
-				localCallback(null, returnItem);
-			}).catch((error) => callback(error));
+			resultPromise.then((returnItem) => localCallback(null, returnItem), (error) => localCallback(error));
 		} else {
-			return (async (): Promise<Item> => {
-				await promise;
-				this.getInternalProperties(internalProperties).storedInDynamo = true;
-
-				const returnItem = new (this.getInternalProperties(internalProperties).model).Item(savedItem as any);
-				returnItem.getInternalProperties(internalProperties).storedInDynamo = true;
-
-				return returnItem;
-			})();
+			return resultPromise;
 		}
 	}
 

--- a/packages/dynamoose/lib/Item.ts
+++ b/packages/dynamoose/lib/Item.ts
@@ -574,8 +574,8 @@ Item.attributesWithSchema = async function (item: Item, model: Model<Item>): Pro
 
 		Object.keys(treeNode).forEach((attr) => {
 			if (attr === "0") {
-				// We check for empty objects here (added `typeof node === "object" && Object.keys(node).length == 0`, see PR https://github.com/dynamoose/dynamoose/pull/1034) to handle the use case of 2d arrays, or arrays within arrays. `node` in that case will be an empty object.
-				if (!node || node.length == 0 || typeof node === "object" && Object.keys(node).length == 0) {
+				// Anything that isn't a non-empty array has no indices to walk, so we fake the path. This covers a missing node, an empty array, a non-array object, and the empty object used for 2d arrays, or arrays within arrays (see PR https://github.com/dynamoose/dynamoose/pull/1034).
+				if (!Array.isArray(node) || node.length == 0) {
 					node = [{}]; // fake the path for arrays
 				}
 				node.forEach((a, index) => {

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -8,7 +8,7 @@ import Internal from "../Internal";
 import {Serializer, SerializerOptions} from "../Serializer";
 import {Condition, ConditionInitializer} from "../Condition";
 import {Scan, Query} from "../ItemRetriever";
-import {CallbackType, ObjectType, FunctionType, ItemArray, ModelType, KeyObject, InputKey} from "../General";
+import {CallbackType, DeepPartial, ObjectType, FunctionType, ItemArray, ModelType, KeyObject, InputKey} from "../General";
 import {PopulateItems} from "../Populate";
 import {AttributeMap} from "../Types";
 import * as DynamoDB from "@aws-sdk/client-dynamodb";
@@ -21,11 +21,11 @@ import returnModel from "../utils/dynamoose/returnModel";
 const {internalProperties} = Internal.General;
 
 type UpdatePartial<T> =
-  | Partial<T>
-  | { $SET: Partial<T> }
-  | { $ADD: Partial<T> }
+  | DeepPartial<T>
+  | { $SET: DeepPartial<T> }
+  | { $ADD: DeepPartial<T> }
   | { $REMOVE: { [K in keyof T]?: null } | string[] }
-  | { $DELETE: Partial<T> };
+  | { $DELETE: DeepPartial<T> };
 
 // Transactions
 type GetTransactionResult = Promise<GetTransactionInput>;
@@ -712,7 +712,7 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 			].reverse();
 
 			if (!updateObj) {
-				updateObj = utils.deep_copy(keyObj) as Partial<T>;
+				updateObj = utils.deep_copy(keyObj) as DeepPartial<T>;
 				Object.keys(await this.getInternalProperties(internalProperties).convertKeyToObject(keyObj)).forEach((key) => delete updateObj[key]);
 			}
 

--- a/packages/dynamoose/lib/Model/index.ts
+++ b/packages/dynamoose/lib/Model/index.ts
@@ -87,6 +87,8 @@ interface ModelUpdateSettings {
 	return?: "item" | "request";
 	condition?: Condition;
 	returnValues?: DynamoDB.ReturnValue;
+	// How nested objects passed to `$SET` are applied. `false` (default) replaces the whole attribute as a map (`SET attr = {..}`), `true` flattens the object into document paths (`SET attr.sub = :v`) so subfields that were not passed in are left untouched.
+	merge?: boolean;
 }
 interface ModelBatchGetItemsResponse<T> extends ItemArray<T> {
 	unprocessedKeys: ObjectType[];
@@ -703,6 +705,33 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 		const table = this.getInternalProperties(internalProperties).table();
 		const {instance} = table.getInternalProperties(internalProperties);
 		let index = 0;
+		// `merge: true` opts IN to flattening a nested object into document paths (`SET attr.sub = :v`), which updates the given subfields and leaves the rest of the map alone. By default the whole attribute is replaced as a map (`SET attr = {..}`).
+		const mergeEnabled = typeof settings === "object" && (settings as ModelUpdateSettings).merge === true;
+
+		const flattenForMerge = (
+			parentPathParts: string[],
+			obj: ObjectType,
+			acc: {ExpressionAttributeNames: ObjectType; ExpressionAttributeValues: ObjectType; UpdateExpression: ObjectType},
+			setOperator: string
+		): void => {
+			for (const key of Object.keys(obj)) {
+				const val = obj[key];
+				const nameKey = `#a${index}`;
+				acc.ExpressionAttributeNames[nameKey] = key;
+				const pathParts = [...parentPathParts, nameKey];
+
+				if (utils.is_plain_object(val) && Object.keys(val).length > 0) {
+					index++;
+					flattenForMerge(pathParts, val, acc, setOperator);
+				} else {
+					const valueKey = `:v${index}`;
+					acc.ExpressionAttributeValues[valueKey] = val;
+					acc.UpdateExpression.SET.push(`${pathParts.join(".")}${setOperator}${valueKey}`);
+					index++;
+				}
+			}
+		};
+
 		const getUpdateExpressionObject: () => Promise<any> = async () => {
 			const updateTypes = [
 				{"name": "$SET", "operator": " = ", "objectFromSchemaSettings": {"validate": true, "enum": true, "forceDefault": true, "required": "nested", "modifiers": ["set"]}},
@@ -739,6 +768,28 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 					try {
 						dynamoType = schema.getAttributeType(subKey, subValue, {"unknownAttributeAllowed": true});
 					} catch (e) {} // eslint-disable-line no-empty
+
+					if (mergeEnabled && dynamoType === "M" && updateType.name === "$SET" && subValue !== null && typeof subValue === "object"
+						&& schema.attributes().some((a) => a.startsWith(`${subKey}.`))) {
+						const schemaSettings = {...updateType.objectFromSchemaSettings, "type": "toDynamo", "customTypesDynamo": true, "saveUnknown": true, "mapAttributes": true, "required": false};
+						const processed = (await this.Item.objectFromSchema({[subKey]: subValue}, this, schemaSettings as any))[subKey];
+						accumulator.ExpressionAttributeNames[`#a${index}`] = subKey;
+						(function flatten (path: string, obj: ObjectType): void {
+							for (const [attr, val] of Object.entries(obj)) {
+								accumulator.ExpressionAttributeNames[`#a${index}`] = attr;
+								const k = `${path}.#a${index++}`;
+								// Only plain objects map to a nested document path. Recursing into other objects (arrays, Sets, Buffers) would emit paths keyed by array indices or byte offsets.
+								if (utils.is_plain_object(val) && Object.keys(val).length > 0) {
+									flatten(k, val);
+								} else {
+									accumulator.ExpressionAttributeValues[`:v${index}`] = val;
+									accumulator.UpdateExpression["SET"].push(`${k} = :v${index++}`);
+								}
+							}
+						})(`#a${index++}`, processed);
+						continue;
+					}
+
 					const attributeExists = schema.attributes().includes(subKey);
 					const dynamooseUndefined = type.UNDEFINED;
 					if (!updateType.attributeOnly && subValue !== dynamooseUndefined) {
@@ -765,22 +816,30 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 						await schema.requiredCheck(subKey, undefined);
 					}
 
-					let expressionValue = updateType.attributeOnly ? "" : `:v${index}`;
-					accumulator.ExpressionAttributeNames[expressionKey] = subKey;
-					if (!updateType.attributeOnly) {
-						accumulator.ExpressionAttributeValues[expressionValue] = subValue;
+					const shouldMerge = mergeEnabled && updateType.name === "$SET" && utils.is_plain_object(subValue) && Object.keys(subValue).length > 0;
+
+					if (shouldMerge) {
+						accumulator.ExpressionAttributeNames[expressionKey] = subKey;
+						index++;
+						flattenForMerge([expressionKey], subValue, accumulator, updateType.operator);
+					} else {
+						let expressionValue = updateType.attributeOnly ? "" : `:v${index}`;
+						accumulator.ExpressionAttributeNames[expressionKey] = subKey;
+						if (!updateType.attributeOnly) {
+							accumulator.ExpressionAttributeValues[expressionValue] = subValue;
+						}
+
+						if (dynamoType === "L" && updateType.name === "$ADD") {
+							expressionValue = `list_append(${expressionKey}, ${expressionValue})`;
+							updateType = updateTypes.find((a) => a.name === "$SET");
+						}
+
+						const operator = updateType.operator || (updateType.attributeOnly ? "" : " ");
+
+						accumulator.UpdateExpression[updateType.name.slice(1)].push(`${expressionKey}${operator}${expressionValue}`);
+
+						index++;
 					}
-
-					if (dynamoType === "L" && updateType.name === "$ADD") {
-						expressionValue = `list_append(${expressionKey}, ${expressionValue})`;
-						updateType = updateTypes.find((a) => a.name === "$SET");
-					}
-
-					const operator = updateType.operator || (updateType.attributeOnly ? "" : " ");
-
-					accumulator.UpdateExpression[updateType.name.slice(1)].push(`${expressionKey}${operator}${expressionValue}`);
-
-					index++;
 				}
 
 				return accumulator;
@@ -847,6 +906,14 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 			});
 
 			await Promise.all(schema.attributes().map(async (attribute) => {
+				// In merge mode, nested attributes (e.g. "config.timeout") are already handled
+				// by objectFromSchema on the parent object, so skip them here to avoid duplicates.
+				if (mergeEnabled && attribute.includes(".")) {
+					const rootAttr = attribute.split(".")[0];
+					if (Object.values(returnObject.ExpressionAttributeNames).includes(rootAttr)) {
+						return;
+					}
+				}
 				const defaultValue = await schema.defaultCheck(attribute, undefined, {"forceDefault": true});
 				if (defaultValue && !Object.values(returnObject.ExpressionAttributeNames).includes(attribute)) {
 					const updateType = updateTypes.find((a) => a.name === "$SET");
@@ -859,9 +926,10 @@ export class Model<T extends ItemCarrier = AnyItem> extends InternalPropertiesCl
 				}
 			}));
 
-			Object.values(returnObject.ExpressionAttributeNames).map((attribute: string, index) => {
-				const value: ValueType = Object.values(returnObject.ExpressionAttributeValues)[index];
-				const valueKey = Object.keys(returnObject.ExpressionAttributeValues)[index];
+			Object.entries(returnObject.ExpressionAttributeNames).forEach(([nameKey, attribute]: [string, string]) => {
+				const valueKey = nameKey.replace("#a", ":v");
+				const value: ValueType = returnObject.ExpressionAttributeValues[valueKey];
+				if (value === undefined) return; // Skip parent-only names used in merge mode document paths
 				let dynamoType;
 				try {
 					dynamoType = schema.getAttributeType(attribute, value, {"unknownAttributeAllowed": true});

--- a/packages/dynamoose/lib/utils/index.ts
+++ b/packages/dynamoose/lib/utils/index.ts
@@ -18,6 +18,7 @@ import childKey from "./childKey";
 import parentKey from "./parentKey";
 import async_reduce from "./async_reduce";
 import keyBy from "./keyBy";
+import is_plain_object from "./is_plain_object";
 
 export default {
 	combine_objects,
@@ -39,5 +40,6 @@ export default {
 	childKey,
 	parentKey,
 	async_reduce,
-	keyBy
+	keyBy,
+	is_plain_object
 };

--- a/packages/dynamoose/lib/utils/is_plain_object.ts
+++ b/packages/dynamoose/lib/utils/is_plain_object.ts
@@ -1,0 +1,11 @@
+// This function is used to determine if a value is a plain object, as opposed to a value that is `typeof "object"` but represents a single value to DynamoDB (arrays, Sets, Dates, Buffers, class instances).
+export default (val: any): boolean => {
+	if (val === null || val === undefined || typeof val !== "object") {
+		return false;
+	}
+	// `Buffer` is a subclass of `Uint8Array`, so the typed array check covers it as well.
+	if (Array.isArray(val) || val instanceof Set || val instanceof Date || val instanceof Uint8Array) {
+		return false;
+	}
+	return val.constructor === undefined || val.constructor === Object;
+};

--- a/packages/dynamoose/lib/utils/merge_objects.ts
+++ b/packages/dynamoose/lib/utils/merge_objects.ts
@@ -47,7 +47,7 @@ const main = (settings: MergeObjectsSettings = {"combineMethod": MergeObjectsCom
 					if (settings.combineMethod === MergeObjectsCombineMethod.ArrayMergeNewArray) {
 						returnObject[key] = [returnObject[key], arg[key]];
 					} else if (typeof returnObject[key] === "number") {
-						returnObject[key] += arg[key];
+						returnObject[key] += arg[key] as number;
 					} else {
 						returnObject[key] = arg[key];
 					}

--- a/packages/dynamoose/test/Item.js
+++ b/packages/dynamoose/test/Item.js
@@ -138,6 +138,20 @@ describe("Item", () => {
 			expect(user.save).toBeInstanceOf(Function);
 		});
 
+		it("Should only call callback once when the save fails", async () => {
+			putItemFunction = () => Promise.reject(new CustomError.OtherError("putItem failed"));
+			const args = [];
+			await new Promise((resolve) => {
+				user.save((error, item) => {
+					args.push([error, item]);
+					setTimeout(resolve, 10);
+				});
+			});
+			expect(args.length).toEqual(1);
+			expect(args[0][0]).toEqual(new CustomError.OtherError("putItem failed"));
+			expect(args[0][1]).not.toBeDefined();
+		});
+
 		const functionCallTypes = [
 			{"name": "Promise", "func": (item) => item.save},
 			{"name": "Callback", "func": (item) => util.promisify(item.save)}

--- a/packages/dynamoose/test/Item.js
+++ b/packages/dynamoose/test/Item.js
@@ -2319,6 +2319,16 @@ describe("Item", () => {
 				"input": {"id": 1, "friends": [[{"name": "Bob", "id": 1}, {"name": "Tim"}]]},
 				"output": ["id", "friends", "friends.0", "friends.0.0", "friends.0.1", "friends.0.0.id", "friends.0.1.id", "friends.0.0.name", "friends.0.1.name"],
 				"schema": {"id": Number, "friends": {"type": Array, "schema": [{"type": Array, "schema":[{"type":"Object", "schema":{"id":{"type":"Number", "required":true}, "name":"String"}}]}]}}
+			},
+			{
+				"input": {"id": 1, "friends": {"name": "Bob"}},
+				"output": ["id", "friends", "friends.0", "friends.0.id", "friends.0.name"],
+				"schema": {"id": Number, "friends": {"type": Array, "schema": [{"type": Object, "schema": {"id": {"type": Number, "required": true}, "name": String}}]}}
+			},
+			{
+				"input": {"id": 1, "friends": [{"name": "Bob", "addresses": {"country": "world"}}]},
+				"output": ["id", "friends", "friends.0", "friends.0.name", "friends.0.addresses", "friends.0.addresses.0", "friends.0.addresses.0.country", "friends.0.addresses.0.zip"],
+				"schema": {"id": Number, "friends": {"type": Array, "schema": [{"type": Object, "schema": {"name": String, "addresses": {"type": Array, "schema": [{"type": Object, "schema": {"country": {"type": String, "required": true}, "zip": Number}}]}}}]}}
 			}
 		];
 

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -2023,6 +2023,7 @@ describe("Model", () => {
 				});
 			});
 		});
+
 	});
 
 	describe("model.batchPut()", () => {
@@ -3509,6 +3510,30 @@ describe("Model", () => {
 					return expect(callType.func(User).bind(User)({"id": 1}, {"friends": ["Bob"]})).resolves.toEqual();
 				});
 
+				it("Should merge nested object properties when {merge: true} is passed", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"name": String, "age": {"type": Number, "required": true}}}});
+					new dynamoose.Table("User", [User]);
+
+					await callType.func(User).bind(User)({"id": 1}, {"data": {"name": "Charlie"}}, {"merge": true});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toEqual("SET #a0.#a1 = :v2");
+					expect(updateItemParams.ExpressionAttributeNames).toEqual({"#a0": "data", "#a1": "name"});
+					expect(updateItemParams.ExpressionAttributeValues).toEqual({":v2": {"S": "Charlie"}});
+				});
+
+				it("Should replace a nested-schema object as a whole map by default", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"name": String, "age": Number}}});
+					new dynamoose.Table("User", [User]);
+
+					await callType.func(User).bind(User)({"id": 1}, {"data": {"name": "Charlie", "age": 30}});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toEqual("SET #a0 = :v0");
+					expect(updateItemParams.ExpressionAttributeNames).toEqual({"#a0": "data"});
+					expect(updateItemParams.ExpressionAttributeValues).toEqual({":v0": {"M": {"name": {"S": "Charlie"}, "age": {"N": "30"}}}});
+				});
+
 				it("Should throw error if trying to replace object without nested required property", () => {
 					updateItemFunction = () => Promise.resolve({});
 					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"name": String, "age": {"type": Number, "required": true}}}});
@@ -3523,6 +3548,114 @@ describe("Model", () => {
 					new dynamoose.Table("User", [User]);
 
 					return expect(callType.func(User).bind(User)({"id": 1}, {"$SET": {"data": {"name": "Charlie"}}})).rejects.toEqual(new CustomError.ValidationError("data.age is a required property but has no value when trying to save item"));
+				});
+
+				it("Should merge nested object properties with $SET when {merge: true} is passed", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"name": String, "age": {"type": Number, "required": true}}}});
+					new dynamoose.Table("User", [User]);
+
+					await callType.func(User).bind(User)({"id": 1}, {"$SET": {"data": {"name": "Charlie"}}}, {"merge": true});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toEqual("SET #a0.#a1 = :v2");
+					expect(updateItemParams.ExpressionAttributeNames).toEqual({"#a0": "data", "#a1": "name"});
+					expect(updateItemParams.ExpressionAttributeValues).toEqual({":v2": {"S": "Charlie"}});
+				});
+
+				it("Should treat an array nested in a map as a leaf value", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"name": String, "tags": {"type": Array, "schema": [String]}}}});
+					new dynamoose.Table("User", [User]);
+
+					await callType.func(User).bind(User)({"id": 1}, {"data": {"name": "Charlie", "tags": ["a", "b"]}}, {"merge": true});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toEqual("SET #a0.#a1 = :v2, #a0.#a3 = :v4");
+					expect(updateItemParams.ExpressionAttributeNames).toEqual({"#a0": "data", "#a1": "name", "#a3": "tags"});
+					expect(updateItemParams.ExpressionAttributeValues).toEqual({":v2": {"S": "Charlie"}, ":v4": {"L": [{"S": "a"}, {"S": "b"}]}});
+				});
+
+				it("Should treat a set nested in a map as a leaf value", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"name": String, "tags": {"type": Set, "schema": [String]}}}});
+					new dynamoose.Table("User", [User]);
+
+					await callType.func(User).bind(User)({"id": 1}, {"data": {"name": "Charlie", "tags": new Set(["a", "b"])}}, {"merge": true});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toEqual("SET #a0.#a1 = :v2, #a0.#a3 = :v4");
+					expect(updateItemParams.ExpressionAttributeNames).toEqual({"#a0": "data", "#a1": "name", "#a3": "tags"});
+					expect(updateItemParams.ExpressionAttributeValues).toEqual({":v2": {"S": "Charlie"}, ":v4": {"SS": ["a", "b"]}});
+				});
+
+				it("Should treat a buffer nested in a map as a leaf value", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"name": String, "blob": Buffer}}});
+					new dynamoose.Table("User", [User]);
+
+					await callType.func(User).bind(User)({"id": 1}, {"data": {"name": "Charlie", "blob": Buffer.from("hi")}}, {"merge": true});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toEqual("SET #a0.#a1 = :v2, #a0.#a3 = :v4");
+					expect(updateItemParams.ExpressionAttributeNames).toEqual({"#a0": "data", "#a1": "name", "#a3": "blob"});
+					expect(updateItemParams.ExpressionAttributeValues).toEqual({":v2": {"S": "Charlie"}, ":v4": {"B": Buffer.from("hi")}});
+				});
+
+				it("Should still flatten a map nested inside a map", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"name": String, "inner": {"type": Object, "schema": {"deep": String}}}}});
+					new dynamoose.Table("User", [User]);
+
+					await callType.func(User).bind(User)({"id": 1}, {"data": {"name": "Charlie", "inner": {"deep": "value"}}}, {"merge": true});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toEqual("SET #a0.#a1 = :v2, #a0.#a3.#a4 = :v5");
+					expect(updateItemParams.ExpressionAttributeNames).toEqual({"#a0": "data", "#a1": "name", "#a3": "inner", "#a4": "deep"});
+					expect(updateItemParams.ExpressionAttributeValues).toEqual({":v2": {"S": "Charlie"}, ":v5": {"S": "value"}});
+				});
+
+				it("Should deep-merge a plain object $SET when {merge: true} is passed", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					const schema = new dynamoose.Schema({"id": Number, "data": {"type": Object}}, {"saveUnknown": true});
+					User = dynamoose.model("User", schema);
+					new dynamoose.Table("User", [User]);
+
+					await callType.func(User).bind(User)({"id": 1}, {"$SET": {"data": {"profile": {"name": "Charlie"}, "age": 30}}}, {"merge": true});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toEqual("SET #a0.#a1.#a2 = :v2, #a0.#a3 = :v3");
+					expect(updateItemParams.ExpressionAttributeNames).toEqual({"#a0": "data", "#a1": "profile", "#a2": "name", "#a3": "age"});
+					expect(updateItemParams.ExpressionAttributeValues).toEqual({":v2": {"S": "Charlie"}, ":v3": {"N": "30"}});
+				});
+
+				it("Should skip nested default attributes when {merge: true} is passed on a typed map", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"name": String, "age": {"type": Number, "default": 5}}}});
+					new dynamoose.Table("User", [User]);
+
+					await callType.func(User).bind(User)({"id": 1}, {"data": {"name": "Charlie"}}, {"merge": true});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toEqual("SET #a0.#a1 = :v2");
+					expect(updateItemParams.ExpressionAttributeNames).toEqual({"#a0": "data", "#a1": "name"});
+					expect(Object.values(updateItemParams.ExpressionAttributeNames)).not.toContain("age");
+				});
+
+				it("Should treat non-plain-object nested values as leaves when {merge: true} is passed", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					const schema = new dynamoose.Schema({"id": Number, "data": {"type": Object}}, {"saveUnknown": true});
+					User = dynamoose.model("User", schema);
+					new dynamoose.Table("User", [User]);
+
+					await callType.func(User).bind(User)({"id": 1}, {"$SET": {"data": {"tags": ["a"], "buf": Buffer.from("x"), "u8": new Uint8Array([1])}}}, {"merge": true});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toContain("#a0.#a");
+					expect(Object.values(updateItemParams.ExpressionAttributeNames)).toEqual(expect.arrayContaining(["data", "tags", "buf", "u8"]));
+				});
+
+				it("Should recursively flatten a deeply nested map attribute on $SET", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					User = dynamoose.model("User", {"id": Number, "data": {"type": Object, "schema": {"profile": {"type": Object, "schema": {"name": String}}}}});
+					new dynamoose.Table("User", [User]);
+
+					await callType.func(User).bind(User)({"id": 1}, {"data": {"profile": {"name": "Charlie"}}}, {"merge": true});
+					expect(updateItemParams).toBeInstanceOf(Object);
+					expect(updateItemParams.UpdateExpression).toContain("#a0.#a");
+					expect(Object.values(updateItemParams.ExpressionAttributeNames)).toEqual(expect.arrayContaining(["data", "profile", "name"]));
 				});
 
 				it("Should use default value if deleting property", async () => {
@@ -4732,7 +4865,13 @@ describe("Model", () => {
 
 			it("Should not delete keys from object", () => {
 				const obj = {"id": 1, "name": "Bob"};
-				User.transaction.update(obj, utils.empty_function);
+				const oldWarn = console.warn; // eslint-disable-line no-console
+				console.warn = () => {}; // eslint-disable-line no-console
+				try {
+					User.transaction.update(obj, utils.empty_function);
+				} finally {
+					console.warn = oldWarn; // eslint-disable-line no-console
+				}
 				expect(obj).toEqual({"id": 1, "name": "Bob"});
 			});
 		});

--- a/packages/dynamoose/test/Model.js
+++ b/packages/dynamoose/test/Model.js
@@ -1998,10 +1998,10 @@ describe("Model", () => {
 					// Check original timestamps
 					expect(result.id).toEqual(1);
 					expect(result.name).toEqual("Charlie");
-					expect(typeof result.createdAt).toEqual("number");
-					expect(result.createdAt).toBeWithinRange(date1 - 10, date1 + 10);
-					expect(typeof result.updatedAt).toEqual("number");
-					expect(result.updatedAt).toBeWithinRange(date1 - 10, date1 + 10);
+					expect(result.createdAt).toBeInstanceOf(Date);
+					expect(result.createdAt.getTime()).toBeWithinRange(date1 - 10, date1 + 10);
+					expect(result.updatedAt).toBeInstanceOf(Date);
+					expect(result.updatedAt.getTime()).toBeWithinRange(date1 - 10, date1 + 10);
 
 					await new Promise((resolve) => setTimeout(resolve, 20));
 
@@ -2015,15 +2015,48 @@ describe("Model", () => {
 					[result, result2].forEach((r) => {
 						expect(r.id).toEqual(1);
 						expect(r.name).toEqual("Charlie 2");
-						expect(typeof r.createdAt).toEqual("number");
-						expect(r.createdAt).toBeWithinRange(date1 - 10, date1 + 10);
-						expect(typeof r.updatedAt).toEqual("number");
-						expect(r.updatedAt).toBeWithinRange(date2 - 10, date2 + 10);
+						expect(r.createdAt).toBeInstanceOf(Date);
+						expect(r.createdAt.getTime()).toBeWithinRange(date1 - 10, date1 + 10);
+						expect(r.updatedAt).toBeInstanceOf(Date);
+						expect(r.updatedAt.getTime()).toBeWithinRange(date2 - 10, date2 + 10);
 					});
 				});
 			});
 		});
 
+		it("Should use custom type for Date attributes in both create and get", async () => {
+			const timestamp = Date.now();
+			createItemFunction = () => Promise.resolve();
+			const dateSchema = new dynamoose.Schema({
+				"id": String,
+				"someDate": {
+					"type": Date
+				}
+			});
+			const DateModel = dynamoose.model("DateModel", dateSchema);
+			new dynamoose.Table("DateModel", [DateModel]);
+			dynamoose.aws.ddb.set({
+				"putItem": (params) => {
+					createItemParams = params;
+					return createItemFunction();
+				},
+				"getItem": () => Promise.resolve({"Item": {"id": {"S": "test"}, "someDate": {"N": `${timestamp}`}}})
+			});
+
+			// Create with a timestamp number
+			const createdItem = await DateModel.create({
+				"id": "test",
+				"someDate": timestamp
+			});
+			const gotItem = await DateModel.get("test");
+
+			// Both create and get should normalize the attribute to the same Date representation
+			expect(createdItem.someDate).toBeInstanceOf(Date);
+			expect(createdItem.someDate.getTime()).toEqual(timestamp);
+			expect(gotItem.someDate).toBeInstanceOf(Date);
+			expect(gotItem.someDate.getTime()).toEqual(timestamp);
+			expect(createdItem.someDate).toEqual(gotItem.someDate);
+		});
 	});
 
 	describe("model.batchPut()", () => {

--- a/packages/dynamoose/test/types/Model.ts
+++ b/packages/dynamoose/test/types/Model.ts
@@ -78,6 +78,10 @@ export class User extends Item {
 	name!: string;
 	age!: number;
 	friends!: string[];
+	settings!: {
+		theme: string;
+		notifications: boolean;
+	};
 }
 const userSchema = new dynamoose.Schema({
 	"id": String,
@@ -117,4 +121,11 @@ UserTypedModel.update({"id": "foo"}, {
 
 UserTypedModel.update({"id": "foo"}, {
 	"$REMOVE":{"age":null}
+});
+
+UserTypedModel.update({"id": "foo"}, {
+	"settings": {"theme": "dark"}
+});
+UserTypedModel.update({"id": "foo"}, {
+	"$SET": {"settings": {"notifications": false}}
 });

--- a/packages/dynamoose/test/utils/is_plain_object.js
+++ b/packages/dynamoose/test/utils/is_plain_object.js
@@ -1,0 +1,39 @@
+const utils = require("../../dist/utils").default;
+
+describe("utils.is_plain_object", () => {
+	it("Should be a function", () => {
+		expect(utils.is_plain_object).toBeInstanceOf(Function);
+	});
+
+	class MyClass {
+		constructor () {
+			this.a = 1;
+		}
+	}
+
+	const tests = [
+		{"name": "empty object literal", "input": {}, "output": true},
+		{"name": "populated object literal", "input": {"a": 1}, "output": true},
+		{"name": "nested object literal", "input": {"a": {"b": 1}}, "output": true},
+		{"name": "null prototype object", "input": Object.create(null), "output": true},
+		{"name": "null", "input": null, "output": false},
+		{"name": "undefined", "input": undefined, "output": false},
+		{"name": "string", "input": "hello", "output": false},
+		{"name": "number", "input": 1, "output": false},
+		{"name": "boolean", "input": true, "output": false},
+		{"name": "function", "input": () => {}, "output": false},
+		{"name": "empty array", "input": [], "output": false},
+		{"name": "populated array", "input": [1, 2], "output": false},
+		{"name": "Set", "input": new Set(["a"]), "output": false},
+		{"name": "Date", "input": new Date(), "output": false},
+		{"name": "Buffer", "input": Buffer.from("hello"), "output": false},
+		{"name": "Uint8Array", "input": new Uint8Array([1, 2]), "output": false},
+		{"name": "class instance", "input": new MyClass(), "output": false}
+	];
+
+	tests.forEach((test) => {
+		it(`Should return ${test.output} for ${test.name}`, () => {
+			expect(utils.is_plain_object(test.input)).toEqual(test.output);
+		});
+	});
+});


### PR DESCRIPTION
### Summary:

Six independent `Item` / `Model` fixes, rebased into one commit per concern. Two are behavioral, the rest are a crash fix, a build fix, a type-only change, and a new opt-in setting.

The branch was restructured after the first review round. The nested `$SET` change that prompted the breaking-change question is now **opt-in** (`{merge: true}`) and the default behavior is unchanged. The only remaining breaking change is `Item.save` returning custom types consistently with `Model.get`.

| Commit | What |
|--------|------|
| `fix(model)` DeepPartial typing | Type-only. `Partial<T>` did not recurse, so partially specified nested attributes were rejected at the type level |
| `fix(item)` array attribute crash | `attributesWithSchema` threw `node.forEach is not a function` when an object was supplied for an attribute the schema declares as an array |
| `fix(utils)` merge_objects cast | `main` does not currently compile: `Operator '+=' cannot be applied to types 'number' and 'T'` |
| `feat(utils)` is_plain_object | New helper + 18 unit tests |
| `feat(update)` `{merge: true}` | Opt-in nested attribute update via document paths. Default unchanged |
| `fix(item)` save callback | The save callback was invoked twice when the callback itself threw |
| `fix(item)` save custom types | 🚨 Breaking. `save` now resolves custom types in the same representation as `get` |

### Code sample:

#### Schema

```js
const schema = new dynamoose.Schema({
	"id": Number,
	"data": {
		"type": Object,
		"schema": {
			"name": String,
			"age": {"type": Number, "required": true}
		}
	}
});
```

#### Model

```js
// Default — unchanged. The whole attribute is replaced as a map.
await User.update({"id": 1}, {"data": {"name": "Charlie", "age": 30}});
// SET #a0 = :v0   ->   data = {"name": "Charlie", "age": 30}

// Omitting a nested required property still fails validation, as before.
await User.update({"id": 1}, {"data": {"name": "Charlie"}});
// ValidationError: data.age is a required property but has no value when trying to save item

// New — {merge: true} writes each provided property to its own document path.
await User.update({"id": 1}, {"data": {"name": "Charlie"}}, {"merge": true});
// SET #a0.#a1 = :v2   ->   data.age is left untouched
```

#### General

```js
// Merging works at any depth, and on saveUnknown objects with no nested schema.
await User.update({"id": 1}, {"$SET": {"data": {"profile": {"name": "Charlie"}}}}, {"merge": true});
// SET #a0.#a1.#a2 = :v3
```

### Other information:

**Why `{merge: true}` exists.** On `main` there is no way to express a nested attribute update, which DynamoDB supports natively as `SET data.#name = :value`. The whole-object form replaces the map and trips nested `required` checks, and the dotted-key form does not produce a document path:

```js
await User.update({"id": 1}, {"data.name": "Charlie"});
// ExpressionAttributeNames: {"#a0": "data.name"}
// #a0 substitutes the entire string, so this targets a top-level attribute
// whose NAME contains a dot — not data -> name.
```

`{merge: true}` emits `SET #a0.#a1 = :v2` with separate name placeholders, which is the shape the raw SDK uses. Only plain objects are flattened — arrays, Sets, Dates and Buffers are written as leaf values, since recursing into them would emit paths keyed by array indices or byte offsets.

A nested document path requires the parent map to already exist on the item, so `merge` is left unset when the attribute may not exist yet. This is documented in the new "Updating nested objects" section.

**On the breaking change.** `Item.save` applied custom type conversion only to the item it constructed for the return value, not to the item being saved, so `create` and `get` disagreed:

| | before | after |
|---|---|---|
| `save()` → `Date` attribute | `number` | `Date` |
| `save()` → `createdAt` | `number` | `Date` |
| `get()` → `Date` attribute | `Date` | `Date` |

`get` was already correct; this makes `save` agree with it. The point is not the return type as such — it is that a schema declared type should be what you get back from every method. Right now `Date` in the schema means a `Date` from `get` and a `number` from `save`, so the schema means one thing on read and another on write.

The clearest evidence is a test this branch previously had to disable. `Should return correct result after saving with timestamps` asserts `result.toJSON()` equals `result2.toJSON()` after a save and a re-save. That assertion is restored and passing — save and re-save now serialize identically, and so do `save` and `get`.

Because of that I would rather not split this commit out. Landing the rest without it leaves the read/write inconsistency in place, which seems worse than the breaking change itself. If you would prefer it target the next major, that works too — but as a version decision rather than by separating it from the fixes it belongs with.

### Type (select 1):
- [x] Bug fix
- [x] Feature implementation
- [x] Documentation improvement
- [x] Testing improvement

### Is this a breaking change? (select 1):
- [x] 🚨 YES 🚨
- [ ] No
- [ ] I'm not sure

<!-- Only the `fix(item): return custom types consistently from save and get` commit is breaking. The nested $SET change is now opt-in and the default is unchanged. -->

### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No

### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No

<!-- 2401 passing. 29 failures in test/Logger.js are pre-existing on `main` and unrelated to this branch — identical count and identical tests on both. -->

### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above

---

This pull request was created by an AI agent (Claude Code, Opus 5). The human contributor directed the work and made the design decisions — including the decision to make the nested `$SET` change opt-in rather than the default, and to revert the `.vscode` and `tsconfig` changes — reviewed every change, challenged and corrected the agent's analysis on several points, and approved the submission. The AI agent wrote the code changes and tests, ran the test suite, restructured the commit history, and drafted this description.

