### PR TITLE
feat(schema): native multi-attribute composite GSI keys

### DIFF
--- a/docs/docs_src/guide/Schema.md
+++ b/docs/docs_src/guide/Schema.md
@@ -232,3 +232,57 @@ dyno_jsdoc_dist/Schema.d.ts|AttributeDefinition.defaultMap
 ### defaultAlias: string
 
 This property is the same as [`defaultMap`](#defaultmap-string) and used as an alias for that property.
+
+## Multi-attribute GSI keys
+
+The per-attribute [`index`](#index-boolean--object--array) setting lets you declare a secondary index whose partition key (and optionally range key) is a single attribute. If you need a global secondary index whose partition key and/or range key is composed of **multiple** attributes, declare it at the top level of your schema settings using `indexes.global`.
+
+`indexes.global` is an array of index declarations. Each declaration has a `name`, a `hashKey` array, and an optional `rangeKey` array. The attributes are listed in `KeySchema` order (the order the composite key is built from).
+
+```js
+const schema = new dynamoose.Schema({
+	"matchId": {"type": String, "hashKey": true},
+	"tournamentId": String,
+	"region": String,
+	"round": String,
+	"bracket": String
+}, {
+	"indexes": {
+		"global": [
+			{
+				"name": "TournamentRegionIndex",
+				"hashKey": ["tournamentId", "region"],
+				"rangeKey": ["round", "bracket", "matchId"]
+			}
+		]
+	}
+});
+```
+
+Unlike the [`Combine`](#attribute-types) type, which concatenates multiple attributes into a single synthetic string attribute, multi-attribute GSI keys map directly onto DynamoDB's native composite key support. Each key attribute keeps its declared type (String, Number, or Binary), so a Number key sorts numerically (no zero-padding) and a Binary key stays binary.
+
+### Rules & limits
+
+- **Global secondary indexes only.** Multi-attribute keys are supported on global secondary indexes only — not on the base table and not on local secondary indexes. Declaring one under `indexes.local` throws an `InvalidParameter` error: `Multi-attribute keys are only supported on global secondary indexes, not local indexes.`
+- **Up to 4 attributes per key.** Each of `hashKey` and `rangeKey` may list at most 4 attributes (up to 8 attributes total per index). Exceeding 4 throws an `InvalidParameter` error.
+- **Every member must be a declared schema attribute.** An attribute named in `hashKey` or `rangeKey` that is not declared in the schema throws an `InvalidParameter` error.
+- **No attribute in both keys.** The same attribute cannot appear in both the `hashKey` and `rangeKey` of a single index. Doing so throws an `InvalidParameter` error.
+
+### Querying a multi-attribute index
+
+When querying a multi-attribute index:
+
+- Every partition-key attribute must be matched with an equality condition.
+- Sort-key attributes are matched left-to-right with no skipping.
+- A non-equality condition (`>`, `<`, `>=`, `<=`, `between`, or `beginsWith`) may only be used on the **last** condition in the query.
+
+```js
+await Match.query({"tournamentId": "T1", "region": "NA"})
+	.where("round").eq("QF")
+	.using("TournamentRegionIndex")
+	.exec();
+```
+
+### Backward compatibility
+
+The existing per-attribute [`index`](#index-boolean--object--array) syntax (including a single-string `rangeKey`) is unchanged and continues to work. Multi-attribute key arrays are an additive opt-in; you only use `indexes.global` when you need a composite key with more than one attribute.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "js-object-utilities": "^2.2.1"
       },
       "devDependencies": {
-        "@types/node": "^20.10.6",
+        "@types/node": "^20.19.43",
         "@typescript-eslint/eslint-plugin": "^6.16.0",
         "eslint": "^8.56.0",
         "eslint-plugin-no-only-tests": "^3.1.0",
@@ -60,721 +60,334 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.966.0.tgz",
-      "integrity": "sha512-u5zA3T9L5pMDV7YBHkGec6cAhnEyiKcd+HjLdJsRBCmMvq8CDZ1+uNusiKqYc7hUi3b8RF5bzGBZphWgUJQWZA==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1097.0.tgz",
+      "integrity": "sha512-LSn51uzuJLkZkCI3JjjnXow81rV3vVxm6vdoPu0NYm7jW8CUJ0qKVivze/SOkmne6Li+a8375RzxNgJipmKbjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/credential-provider-node": "3.966.0",
-        "@aws-sdk/dynamodb-codec": "3.966.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.965.0",
-        "@aws-sdk/middleware-host-header": "3.965.0",
-        "@aws-sdk/middleware-logger": "3.965.0",
-        "@aws-sdk/middleware-recursion-detection": "3.965.0",
-        "@aws-sdk/middleware-user-agent": "3.966.0",
-        "@aws-sdk/region-config-resolver": "3.965.0",
-        "@aws-sdk/types": "3.965.0",
-        "@aws-sdk/util-endpoints": "3.965.0",
-        "@aws-sdk/util-user-agent-browser": "3.965.0",
-        "@aws-sdk/util-user-agent-node": "3.966.0",
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/core": "^3.20.1",
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/hash-node": "^4.2.7",
-        "@smithy/invalid-dependency": "^4.2.7",
-        "@smithy/middleware-content-length": "^4.2.7",
-        "@smithy/middleware-endpoint": "^4.4.2",
-        "@smithy/middleware-retry": "^4.4.18",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.17",
-        "@smithy/util-defaults-mode-node": "^4.2.20",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.7",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/dynamodb-codec": "^3.973.37",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.26",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.966.0.tgz",
-      "integrity": "sha512-hQZDQgqRJclALDo9wK+bb5O+VpO8JcjImp52w9KPSz9XveNRgE9AYfklRJd8qT2Bwhxe6IbnqYEino2wqUMA1w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/middleware-host-header": "3.965.0",
-        "@aws-sdk/middleware-logger": "3.965.0",
-        "@aws-sdk/middleware-recursion-detection": "3.965.0",
-        "@aws-sdk/middleware-user-agent": "3.966.0",
-        "@aws-sdk/region-config-resolver": "3.965.0",
-        "@aws-sdk/types": "3.965.0",
-        "@aws-sdk/util-endpoints": "3.965.0",
-        "@aws-sdk/util-user-agent-browser": "3.965.0",
-        "@aws-sdk/util-user-agent-node": "3.966.0",
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/core": "^3.20.1",
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/hash-node": "^4.2.7",
-        "@smithy/invalid-dependency": "^4.2.7",
-        "@smithy/middleware-content-length": "^4.2.7",
-        "@smithy/middleware-endpoint": "^4.4.2",
-        "@smithy/middleware-retry": "^4.4.18",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.17",
-        "@smithy/util-defaults-mode-node": "^4.2.20",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.966.0.tgz",
-      "integrity": "sha512-QaRVBHD1prdrFXIeFAY/1w4b4S0EFyo/ytzU+rCklEjMRT7DKGXGoHXTWLGz+HD7ovlS5u+9cf8a/LeSOEMzww==",
+      "version": "3.977.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.2.tgz",
+      "integrity": "sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.965.0",
-        "@aws-sdk/xml-builder": "3.965.0",
-        "@smithy/core": "^3.20.1",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/signature-v4": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.966.0.tgz",
-      "integrity": "sha512-sxVKc9PY0SH7jgN/8WxhbKQ7MWDIgaJv1AoAKJkhJ+GM5r09G5Vb2Vl8ALYpsy+r8b+iYpq5dGJj8k2VqxoQMg==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.63.tgz",
+      "integrity": "sha512-VSS9dftt7r7GiZ4gs8z0PNaMLVAaSj/MXVr6WQBtsrQQB9miJo7I6lQuJND1/ugFwK9x7OHCYZDkLSYh0FIZtA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.966.0.tgz",
-      "integrity": "sha512-VTJDP1jOibVtc5pn5TNE12rhqOO/n10IjkoJi8fFp9BMfmh3iqo70Ppvphz/Pe/R9LcK5Z3h0Z4EB9IXDR6kag==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.65.tgz",
+      "integrity": "sha512-SH/ec7p1J0CfC28+ypH38IwGENd7tQEvTpmuRSlinthiGxKlwzJbXGXxIMAhn0/lpxnIxudNmCsw3Cy0PDRoAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-stream": "^4.5.8",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.966.0.tgz",
-      "integrity": "sha512-4oQKkYMCUx0mffKuH8LQag1M4Fo5daKVmsLAnjrIqKh91xmCrcWlAFNMgeEYvI1Yy125XeNSaFMfir6oNc2ODA==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.8.tgz",
+      "integrity": "sha512-alkQpDUHsjHGVXvlV0XFXpPfh9+aTMmN6UYRky0Qky8SbvdxoQdDHftT4uugq8XShP6WtDQW7bo5YQ0SfNSxRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/credential-provider-env": "3.966.0",
-        "@aws-sdk/credential-provider-http": "3.966.0",
-        "@aws-sdk/credential-provider-login": "3.966.0",
-        "@aws-sdk/credential-provider-process": "3.966.0",
-        "@aws-sdk/credential-provider-sso": "3.966.0",
-        "@aws-sdk/credential-provider-web-identity": "3.966.0",
-        "@aws-sdk/nested-clients": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/credential-provider-imds": "^4.2.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-login": "^3.972.70",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.966.0.tgz",
-      "integrity": "sha512-wD1KlqLyh23Xfns/ZAPxebwXixoJJCuDbeJHFrLDpP4D4h3vA2S8nSFgBSFR15q9FhgRfHleClycf6g5K4Ww6w==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.70.tgz",
+      "integrity": "sha512-JlUjK6bYJAxN9PkWWCI/TiOYEdvXNKq61x2DTaEKxRMxAOYNk2LX8m4wVtDFxTZwyXx7Tpmxb49dNprkW/uqXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/nested-clients": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.966.0.tgz",
-      "integrity": "sha512-7QCOERGddMw7QbjE+LSAFgwOBpPv4px2ty0GCK7ZiPJGsni2EYmM4TtYnQb9u1WNHmHqIPWMbZR0pKDbyRyHlQ==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.74.tgz",
+      "integrity": "sha512-V+7pzT0OzROL2uKcQ2+MpnfwKONvozYojmdn8RguAMX9o48gtSVvt+7aCkwWCH2thDXOnUPCN6qn4kiFDelZWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.966.0",
-        "@aws-sdk/credential-provider-http": "3.966.0",
-        "@aws-sdk/credential-provider-ini": "3.966.0",
-        "@aws-sdk/credential-provider-process": "3.966.0",
-        "@aws-sdk/credential-provider-sso": "3.966.0",
-        "@aws-sdk/credential-provider-web-identity": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/credential-provider-imds": "^4.2.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-ini": "^3.973.8",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.966.0.tgz",
-      "integrity": "sha512-q5kCo+xHXisNbbPAh/DiCd+LZX4wdby77t7GLk0b2U0/mrel4lgy6o79CApe+0emakpOS1nPZS7voXA7vGPz4w==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.63.tgz",
+      "integrity": "sha512-lPt2oGMcvP3uPhhxX5EquHrzBI/ZgJce+CHKcOGZl2ZQAXLLSxu7k/Cgo0HIktyi9dmDFljbOkj4XAnXD93YVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.966.0.tgz",
-      "integrity": "sha512-Rv5aEfbpqsQZzxpX2x+FbSyVFOE3Dngome+exNA8jGzc00rrMZEUnm3J3yAsLp/I2l7wnTfI0r2zMe+T9/nZAQ==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.7.tgz",
+      "integrity": "sha512-FR2b+7QNXP/q+eslVzrCjGKvso8Lcr/B18BvFyD2iLNhq42XSo+wnh8FfX6mtqgaVsL1vuB27uGXuY+xUTa7pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.966.0",
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/token-providers": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/token-providers": "3.1097.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.966.0.tgz",
-      "integrity": "sha512-Yv1lc9iic9xg3ywMmIAeXN1YwuvfcClLVdiF2y71LqUgIOupW8B8my84XJr6pmOQuKzZa++c2znNhC9lGsbKyw==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.69.tgz",
+      "integrity": "sha512-RWNTKGXRkzMJe8bgIAdlz9q0N97m7fThD9KOjBt2CSY+/xnIbrA1/Dnm/ZEz8ZeQ1Of5D+fLaPeoD3lGt6AU4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/nested-clients": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.966.0.tgz",
-      "integrity": "sha512-wxVtcbBw4oUwq8+/4GH89ODdwXGQeknk27eIvP6471G7Ak4hNPlsshD8bZNeKbMlxTMqnu7Av5TTznfTtujjFw==",
+      "version": "3.973.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.37.tgz",
+      "integrity": "sha512-NYaWEWv5owB3usPcaVBMcdXbqzBYf2QCf+wU3AP5MpOXRiMF7qE6O1RaCUZGYCM9Lv7jtvfqCrmgYiicshyYeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.966.0",
-        "@smithy/core": "^3.20.1",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.966.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.965.0.tgz",
-      "integrity": "sha512-7bqt08b1aVgHHRbdUK9iIMI2CKpaeYs3cLNeZ/Js7GRAQIRQ0OsRILNxGdtWrkVbpp8ITM++iWJCGUw/X19EdA==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.9.tgz",
+      "integrity": "sha512-LFvdgq8SriaskUcjpBMDE7J2c9RmuT5v3gU36/znV71EU5DKUis4FmGFjCMelKCCViFeVrQADBAlIiOYRhEx6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.965.0.tgz",
-      "integrity": "sha512-XVUV2FmJnDG0FCCeTw0wniP1EkDR+Dy3Pl91aTkRvUw9OYbTEPLGIZiABn1EKdQPOEc77Y1+FQQ6QbjSZKkJ/A==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.26.tgz",
+      "integrity": "sha512-suOMAYAM43aSyC3cLBvvJIuNyg96nUsPvYQUrq4G+8Prt2qTpFETgaiXX7JP1gIcK5FF0Z2IdyEsPXseZATOPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/endpoint-cache": "3.965.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/endpoint-cache": "^3.972.9",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.965.0.tgz",
-      "integrity": "sha512-SfpSYqoPOAmdb3DBsnNsZ0vix+1VAtkUkzXM79JL3R5IfacpyKE2zytOgVAQx/FjhhlpSTwuXd+LRhUEVb3MaA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.965.0.tgz",
-      "integrity": "sha512-gjUvJRZT1bUABKewnvkj51LAynFrfz2h5DYAg5/2F4Utx6UOGByTSr9Rq8JCLbURvvzAbCtcMkkIJRxw+8Zuzw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.965.0.tgz",
-      "integrity": "sha512-6dvD+18Ni14KCRu+tfEoNxq1sIGVp9tvoZDZ7aMvpnA7mDXuRLrOjRQ/TAZqXwr9ENKVGyxcPl0cRK8jk1YWjA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.965.0",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.966.0.tgz",
-      "integrity": "sha512-MvGoy0vhMluVpSB5GaGJbYLqwbZfZjwEZhneDHdPhgCgQqmCtugnYIIjpUw7kKqWGsmaMQmNEgSFf1zYYmwOyg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@aws-sdk/util-endpoints": "3.965.0",
-        "@smithy/core": "^3.20.1",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.966.0.tgz",
-      "integrity": "sha512-FRzAWwLNoKiaEWbYhnpnfartIdOgiaBLnPcd3uG1Io+vvxQUeRPhQIy4EfKnT3AuA+g7gzSCjMG2JKoJOplDtQ==",
+      "version": "3.997.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.37.tgz",
+      "integrity": "sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/middleware-host-header": "3.965.0",
-        "@aws-sdk/middleware-logger": "3.965.0",
-        "@aws-sdk/middleware-recursion-detection": "3.965.0",
-        "@aws-sdk/middleware-user-agent": "3.966.0",
-        "@aws-sdk/region-config-resolver": "3.965.0",
-        "@aws-sdk/types": "3.965.0",
-        "@aws-sdk/util-endpoints": "3.965.0",
-        "@aws-sdk/util-user-agent-browser": "3.965.0",
-        "@aws-sdk/util-user-agent-node": "3.966.0",
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/core": "^3.20.1",
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/hash-node": "^4.2.7",
-        "@smithy/invalid-dependency": "^4.2.7",
-        "@smithy/middleware-content-length": "^4.2.7",
-        "@smithy/middleware-endpoint": "^4.4.2",
-        "@smithy/middleware-retry": "^4.4.18",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.17",
-        "@smithy/util-defaults-mode-node": "^4.2.20",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.965.0.tgz",
-      "integrity": "sha512-RoMhu9ly2B0coxn8ctXosPP2WmDD0MkQlZGLjoYHQUOCBmty5qmCxOqBmBDa6wbWbB8xKtMQ/4VXloQOgzjHXg==",
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.966.0.tgz",
-      "integrity": "sha512-8k5cBTicTGYJHhKaweO4gL4fud1KDnLS5fByT6/Xbiu59AxYM4E/h3ds+3jxDMnniCE3gIWpEnyfM9khtmw2lA==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1097.0.tgz",
+      "integrity": "sha512-EIsdmy/f5IGc5r01RjKWNvrbBra6z0xudQM0D6Wf8DeGuPoRlubkLqr7VgWijFucO4kg0mtev9H3RX/ZOubUhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/nested-clients": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.965.0.tgz",
-      "integrity": "sha512-jvodoJdMavvg8faN7co58vVJRO5MVep4JFPRzUNCzpJ98BDqWDk/ad045aMJcmxkLzYLS2UAnUmqjJ/tUPNlzQ==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.966.0.tgz",
-      "integrity": "sha512-bc5HmvegLpMVb6zuh3/roq3i+CEacSK2RIZrHijs90r4lENAWlueZQxJz6ZvazlngfnAi1ZVCXOviPUAWKivSA==",
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.7.tgz",
+      "integrity": "sha512-v+WJASG9yaW8qNM7pNSgH1PBYz5mVTf7gzKPi0NqGjLlaCtPdk6EjM1lmv03egA07iXUw6OToGYfW2w8D3kBrg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.966.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.965.0.tgz",
-      "integrity": "sha512-WqSCB0XIsGUwZWvrYkuoofi2vzoVHqyeJ2kN+WyoOsxPLTiQSBIoqm/01R/qJvoxwK/gOOF7su9i84Vw2NQQpQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-endpoints": "^3.2.7",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.0.tgz",
-      "integrity": "sha512-9LJFand4bIoOjOF4x3wx0UZYiFZRo4oUauxQSiEX2dVg+5qeBOJSjp2SeWykIE6+6frCZ5wvWm2fGLK8D32aJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.965.0.tgz",
-      "integrity": "sha512-Xiza/zMntQGpkd2dETQeAK8So1pg5+STTzpcdGWxj5q0jGO5ayjqT/q1Q7BrsX5KIr6PvRkl9/V7lLCv04wGjQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/types": "^4.11.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.966.0.tgz",
-      "integrity": "sha512-vPPe8V0GLj+jVS5EqFz2NUBgWH35favqxliUOvhp8xBdNRkEjiZm5TqitVtFlxS4RrLY3HOndrWbrP5ejbwl1Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
+        "@aws-sdk/client-dynamodb": "^3.1088.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.965.0.tgz",
-      "integrity": "sha512-Tcod25/BTupraQwtb+Q+GX8bmEZfxIFjjJ/AvkhUZsZlkPeVluzq1uu3Oeqf145DCdMjzLIN6vab5MrykbDP+g==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "fast-xml-parser": "5.2.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
-      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -4025,51 +3638,13 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
-      "integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/config-resolver": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
-      "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/core": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.2.tgz",
-      "integrity": "sha512-nc99TseyTwL1bg+T21cyEA5oItNy1XN4aUeyOlXJnvyRW5VSK1oRKRoSM/Iq0KFPuqZMxjBemSZHZCOZbSyBMw==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.0.tgz",
+      "integrity": "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-stream": "^4.5.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4077,15 +3652,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
-      "integrity": "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA==",
+      "version": "4.4.15",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.15.tgz",
+      "integrity": "sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4093,150 +3666,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
-      "integrity": "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.12.tgz",
+      "integrity": "sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/querystring-builder": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.7.tgz",
-      "integrity": "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
-      "integrity": "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
-      "integrity": "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.3.tgz",
-      "integrity": "sha512-Zb8R35hjBhp1oFhiaAZ9QhClpPHdEDmNDC2UrrB2fqV0oNDUUPH12ovZHB5xi/Rd+pg/BJHOR1q+SfsieSKPQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.20.2",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.19.tgz",
-      "integrity": "sha512-QtisFIjIw2tjMm/ESatjWFVIQb5Xd093z8xhxq/SijLg7Mgo2C2wod47Ib/AHpBLFhwYXPzd7Hp2+JVXfeZyMQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.4",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
-        "@smithy/uuid": "^1.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
-      "integrity": "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
-      "integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
-      "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4244,93 +3680,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
-      "integrity": "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ==",
+      "version": "4.9.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.12.tgz",
+      "integrity": "sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/querystring-builder": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/property-provider": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.7.tgz",
-      "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
-      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
-      "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
-      "integrity": "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
-      "integrity": "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
-      "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4338,36 +3694,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
-      "integrity": "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.11.tgz",
+      "integrity": "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/smithy-client": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.4.tgz",
-      "integrity": "sha512-rHig+BWjhjlHlah67ryaW9DECYixiJo5pQCTEwsJyarRBAwHMMC3iYz5MXXAHXe64ZAMn1NhTUSTFIu1T6n6jg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.20.2",
-        "@smithy/middleware-endpoint": "^4.4.3",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-stream": "^4.5.8",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4375,242 +3708,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.11.0.tgz",
-      "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/url-parser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.7.tgz",
-      "integrity": "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.18",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.18.tgz",
-      "integrity": "sha512-Ao1oLH37YmLyHnKdteMp6l4KMCGBeZEAN68YYe00KAaKFijFELDbRQRm3CNplz7bez1HifuBV0l5uR6eVJLhIg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.4",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.21.tgz",
-      "integrity": "sha512-e21ASJDirE96kKXZLcYcnn4Zt0WGOvMYc1P8EK0gQeQ3I8PbJWqBKx9AUr/YeFpDkpYwEu1RsPe4UXk2+QL7IA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/credential-provider-imds": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.4",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
-      "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-middleware": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
-      "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.7.tgz",
-      "integrity": "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.8.tgz",
-      "integrity": "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-waiter": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.7.tgz",
-      "integrity": "sha512-vHJFXi9b7kUEpHWUCY3Twl+9NPOZvQ0SAi+Ewtn48mbiJk4JY9MZmKQjGB4SCvVb9WPiSphZJYY6RIbs+grrzw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4764,12 +3864,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
-      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -5541,9 +4642,9 @@
       }
     },
     "node_modules/bowser": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
-      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -7135,24 +6236,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^2.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -12770,18 +11853,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -13243,10 +12314,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "5.0.0",
@@ -13706,8 +12778,8 @@
       ],
       "license": "Unlicense",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.782.0",
-        "@aws-sdk/util-dynamodb": "^3.782.0",
+        "@aws-sdk/client-dynamodb": "^3.1073.0",
+        "@aws-sdk/util-dynamodb": "^3.996.5",
         "dynamoose-utils": "^4.2.0",
         "js-object-utilities": "^2.2.1"
       },
@@ -13782,571 +12854,255 @@
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
-    "@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "requires": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-          "requires": {
-            "@smithy/is-array-buffer": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        }
-      }
-    },
-    "@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "requires": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "requires": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-          "requires": {
-            "@smithy/is-array-buffer": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        }
-      }
-    },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.966.0.tgz",
-      "integrity": "sha512-u5zA3T9L5pMDV7YBHkGec6cAhnEyiKcd+HjLdJsRBCmMvq8CDZ1+uNusiKqYc7hUi3b8RF5bzGBZphWgUJQWZA==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1097.0.tgz",
+      "integrity": "sha512-LSn51uzuJLkZkCI3JjjnXow81rV3vVxm6vdoPu0NYm7jW8CUJ0qKVivze/SOkmne6Li+a8375RzxNgJipmKbjA==",
       "requires": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/credential-provider-node": "3.966.0",
-        "@aws-sdk/dynamodb-codec": "3.966.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.965.0",
-        "@aws-sdk/middleware-host-header": "3.965.0",
-        "@aws-sdk/middleware-logger": "3.965.0",
-        "@aws-sdk/middleware-recursion-detection": "3.965.0",
-        "@aws-sdk/middleware-user-agent": "3.966.0",
-        "@aws-sdk/region-config-resolver": "3.965.0",
-        "@aws-sdk/types": "3.965.0",
-        "@aws-sdk/util-endpoints": "3.965.0",
-        "@aws-sdk/util-user-agent-browser": "3.965.0",
-        "@aws-sdk/util-user-agent-node": "3.966.0",
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/core": "^3.20.1",
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/hash-node": "^4.2.7",
-        "@smithy/invalid-dependency": "^4.2.7",
-        "@smithy/middleware-content-length": "^4.2.7",
-        "@smithy/middleware-endpoint": "^4.4.2",
-        "@smithy/middleware-retry": "^4.4.18",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.17",
-        "@smithy/util-defaults-mode-node": "^4.2.20",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.7",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/client-sso": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.966.0.tgz",
-      "integrity": "sha512-hQZDQgqRJclALDo9wK+bb5O+VpO8JcjImp52w9KPSz9XveNRgE9AYfklRJd8qT2Bwhxe6IbnqYEino2wqUMA1w==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/middleware-host-header": "3.965.0",
-        "@aws-sdk/middleware-logger": "3.965.0",
-        "@aws-sdk/middleware-recursion-detection": "3.965.0",
-        "@aws-sdk/middleware-user-agent": "3.966.0",
-        "@aws-sdk/region-config-resolver": "3.965.0",
-        "@aws-sdk/types": "3.965.0",
-        "@aws-sdk/util-endpoints": "3.965.0",
-        "@aws-sdk/util-user-agent-browser": "3.965.0",
-        "@aws-sdk/util-user-agent-node": "3.966.0",
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/core": "^3.20.1",
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/hash-node": "^4.2.7",
-        "@smithy/invalid-dependency": "^4.2.7",
-        "@smithy/middleware-content-length": "^4.2.7",
-        "@smithy/middleware-endpoint": "^4.4.2",
-        "@smithy/middleware-retry": "^4.4.18",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.17",
-        "@smithy/util-defaults-mode-node": "^4.2.20",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/dynamodb-codec": "^3.973.37",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.26",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/core": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.966.0.tgz",
-      "integrity": "sha512-QaRVBHD1prdrFXIeFAY/1w4b4S0EFyo/ytzU+rCklEjMRT7DKGXGoHXTWLGz+HD7ovlS5u+9cf8a/LeSOEMzww==",
+      "version": "3.977.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.2.tgz",
+      "integrity": "sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==",
       "requires": {
-        "@aws-sdk/types": "3.965.0",
-        "@aws-sdk/xml-builder": "3.965.0",
-        "@smithy/core": "^3.20.1",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/signature-v4": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.966.0.tgz",
-      "integrity": "sha512-sxVKc9PY0SH7jgN/8WxhbKQ7MWDIgaJv1AoAKJkhJ+GM5r09G5Vb2Vl8ALYpsy+r8b+iYpq5dGJj8k2VqxoQMg==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.63.tgz",
+      "integrity": "sha512-VSS9dftt7r7GiZ4gs8z0PNaMLVAaSj/MXVr6WQBtsrQQB9miJo7I6lQuJND1/ugFwK9x7OHCYZDkLSYh0FIZtA==",
       "requires": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-http": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.966.0.tgz",
-      "integrity": "sha512-VTJDP1jOibVtc5pn5TNE12rhqOO/n10IjkoJi8fFp9BMfmh3iqo70Ppvphz/Pe/R9LcK5Z3h0Z4EB9IXDR6kag==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.65.tgz",
+      "integrity": "sha512-SH/ec7p1J0CfC28+ypH38IwGENd7tQEvTpmuRSlinthiGxKlwzJbXGXxIMAhn0/lpxnIxudNmCsw3Cy0PDRoAg==",
       "requires": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-stream": "^4.5.8",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.966.0.tgz",
-      "integrity": "sha512-4oQKkYMCUx0mffKuH8LQag1M4Fo5daKVmsLAnjrIqKh91xmCrcWlAFNMgeEYvI1Yy125XeNSaFMfir6oNc2ODA==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.8.tgz",
+      "integrity": "sha512-alkQpDUHsjHGVXvlV0XFXpPfh9+aTMmN6UYRky0Qky8SbvdxoQdDHftT4uugq8XShP6WtDQW7bo5YQ0SfNSxRQ==",
       "requires": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/credential-provider-env": "3.966.0",
-        "@aws-sdk/credential-provider-http": "3.966.0",
-        "@aws-sdk/credential-provider-login": "3.966.0",
-        "@aws-sdk/credential-provider-process": "3.966.0",
-        "@aws-sdk/credential-provider-sso": "3.966.0",
-        "@aws-sdk/credential-provider-web-identity": "3.966.0",
-        "@aws-sdk/nested-clients": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/credential-provider-imds": "^4.2.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-login": "^3.972.70",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-login": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.966.0.tgz",
-      "integrity": "sha512-wD1KlqLyh23Xfns/ZAPxebwXixoJJCuDbeJHFrLDpP4D4h3vA2S8nSFgBSFR15q9FhgRfHleClycf6g5K4Ww6w==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.70.tgz",
+      "integrity": "sha512-JlUjK6bYJAxN9PkWWCI/TiOYEdvXNKq61x2DTaEKxRMxAOYNk2LX8m4wVtDFxTZwyXx7Tpmxb49dNprkW/uqXQ==",
       "requires": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/nested-clients": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.966.0.tgz",
-      "integrity": "sha512-7QCOERGddMw7QbjE+LSAFgwOBpPv4px2ty0GCK7ZiPJGsni2EYmM4TtYnQb9u1WNHmHqIPWMbZR0pKDbyRyHlQ==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.74.tgz",
+      "integrity": "sha512-V+7pzT0OzROL2uKcQ2+MpnfwKONvozYojmdn8RguAMX9o48gtSVvt+7aCkwWCH2thDXOnUPCN6qn4kiFDelZWA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.966.0",
-        "@aws-sdk/credential-provider-http": "3.966.0",
-        "@aws-sdk/credential-provider-ini": "3.966.0",
-        "@aws-sdk/credential-provider-process": "3.966.0",
-        "@aws-sdk/credential-provider-sso": "3.966.0",
-        "@aws-sdk/credential-provider-web-identity": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/credential-provider-imds": "^4.2.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-ini": "^3.973.8",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.966.0.tgz",
-      "integrity": "sha512-q5kCo+xHXisNbbPAh/DiCd+LZX4wdby77t7GLk0b2U0/mrel4lgy6o79CApe+0emakpOS1nPZS7voXA7vGPz4w==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.63.tgz",
+      "integrity": "sha512-lPt2oGMcvP3uPhhxX5EquHrzBI/ZgJce+CHKcOGZl2ZQAXLLSxu7k/Cgo0HIktyi9dmDFljbOkj4XAnXD93YVQ==",
       "requires": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.966.0.tgz",
-      "integrity": "sha512-Rv5aEfbpqsQZzxpX2x+FbSyVFOE3Dngome+exNA8jGzc00rrMZEUnm3J3yAsLp/I2l7wnTfI0r2zMe+T9/nZAQ==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.7.tgz",
+      "integrity": "sha512-FR2b+7QNXP/q+eslVzrCjGKvso8Lcr/B18BvFyD2iLNhq42XSo+wnh8FfX6mtqgaVsL1vuB27uGXuY+xUTa7pg==",
       "requires": {
-        "@aws-sdk/client-sso": "3.966.0",
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/token-providers": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/token-providers": "3.1097.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.966.0.tgz",
-      "integrity": "sha512-Yv1lc9iic9xg3ywMmIAeXN1YwuvfcClLVdiF2y71LqUgIOupW8B8my84XJr6pmOQuKzZa++c2znNhC9lGsbKyw==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.69.tgz",
+      "integrity": "sha512-RWNTKGXRkzMJe8bgIAdlz9q0N97m7fThD9KOjBt2CSY+/xnIbrA1/Dnm/ZEz8ZeQ1Of5D+fLaPeoD3lGt6AU4Q==",
       "requires": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/nested-clients": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/dynamodb-codec": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.966.0.tgz",
-      "integrity": "sha512-wxVtcbBw4oUwq8+/4GH89ODdwXGQeknk27eIvP6471G7Ak4hNPlsshD8bZNeKbMlxTMqnu7Av5TTznfTtujjFw==",
+      "version": "3.973.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.37.tgz",
+      "integrity": "sha512-NYaWEWv5owB3usPcaVBMcdXbqzBYf2QCf+wU3AP5MpOXRiMF7qE6O1RaCUZGYCM9Lv7jtvfqCrmgYiicshyYeA==",
       "requires": {
-        "@aws-sdk/core": "3.966.0",
-        "@smithy/core": "^3.20.1",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/endpoint-cache": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.965.0.tgz",
-      "integrity": "sha512-7bqt08b1aVgHHRbdUK9iIMI2CKpaeYs3cLNeZ/Js7GRAQIRQ0OsRILNxGdtWrkVbpp8ITM++iWJCGUw/X19EdA==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.9.tgz",
+      "integrity": "sha512-LFvdgq8SriaskUcjpBMDE7J2c9RmuT5v3gU36/znV71EU5DKUis4FmGFjCMelKCCViFeVrQADBAlIiOYRhEx6Q==",
       "requires": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.965.0.tgz",
-      "integrity": "sha512-XVUV2FmJnDG0FCCeTw0wniP1EkDR+Dy3Pl91aTkRvUw9OYbTEPLGIZiABn1EKdQPOEc77Y1+FQQ6QbjSZKkJ/A==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.26.tgz",
+      "integrity": "sha512-suOMAYAM43aSyC3cLBvvJIuNyg96nUsPvYQUrq4G+8Prt2qTpFETgaiXX7JP1gIcK5FF0Z2IdyEsPXseZATOPw==",
       "requires": {
-        "@aws-sdk/endpoint-cache": "3.965.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/middleware-host-header": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.965.0.tgz",
-      "integrity": "sha512-SfpSYqoPOAmdb3DBsnNsZ0vix+1VAtkUkzXM79JL3R5IfacpyKE2zytOgVAQx/FjhhlpSTwuXd+LRhUEVb3MaA==",
-      "requires": {
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/middleware-logger": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.965.0.tgz",
-      "integrity": "sha512-gjUvJRZT1bUABKewnvkj51LAynFrfz2h5DYAg5/2F4Utx6UOGByTSr9Rq8JCLbURvvzAbCtcMkkIJRxw+8Zuzw==",
-      "requires": {
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.965.0.tgz",
-      "integrity": "sha512-6dvD+18Ni14KCRu+tfEoNxq1sIGVp9tvoZDZ7aMvpnA7mDXuRLrOjRQ/TAZqXwr9ENKVGyxcPl0cRK8jk1YWjA==",
-      "requires": {
-        "@aws-sdk/types": "3.965.0",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/middleware-user-agent": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.966.0.tgz",
-      "integrity": "sha512-MvGoy0vhMluVpSB5GaGJbYLqwbZfZjwEZhneDHdPhgCgQqmCtugnYIIjpUw7kKqWGsmaMQmNEgSFf1zYYmwOyg==",
-      "requires": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@aws-sdk/util-endpoints": "3.965.0",
-        "@smithy/core": "^3.20.1",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/endpoint-cache": "^3.972.9",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/nested-clients": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.966.0.tgz",
-      "integrity": "sha512-FRzAWwLNoKiaEWbYhnpnfartIdOgiaBLnPcd3uG1Io+vvxQUeRPhQIy4EfKnT3AuA+g7gzSCjMG2JKoJOplDtQ==",
+      "version": "3.997.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.37.tgz",
+      "integrity": "sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==",
       "requires": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/middleware-host-header": "3.965.0",
-        "@aws-sdk/middleware-logger": "3.965.0",
-        "@aws-sdk/middleware-recursion-detection": "3.965.0",
-        "@aws-sdk/middleware-user-agent": "3.966.0",
-        "@aws-sdk/region-config-resolver": "3.965.0",
-        "@aws-sdk/types": "3.965.0",
-        "@aws-sdk/util-endpoints": "3.965.0",
-        "@aws-sdk/util-user-agent-browser": "3.965.0",
-        "@aws-sdk/util-user-agent-node": "3.966.0",
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/core": "^3.20.1",
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/hash-node": "^4.2.7",
-        "@smithy/invalid-dependency": "^4.2.7",
-        "@smithy/middleware-content-length": "^4.2.7",
-        "@smithy/middleware-endpoint": "^4.4.2",
-        "@smithy/middleware-retry": "^4.4.18",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.3",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.17",
-        "@smithy/util-defaults-mode-node": "^4.2.20",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/region-config-resolver": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.965.0.tgz",
-      "integrity": "sha512-RoMhu9ly2B0coxn8ctXosPP2WmDD0MkQlZGLjoYHQUOCBmty5qmCxOqBmBDa6wbWbB8xKtMQ/4VXloQOgzjHXg==",
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
       "requires": {
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.966.0.tgz",
-      "integrity": "sha512-8k5cBTicTGYJHhKaweO4gL4fud1KDnLS5fByT6/Xbiu59AxYM4E/h3ds+3jxDMnniCE3gIWpEnyfM9khtmw2lA==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1097.0.tgz",
+      "integrity": "sha512-EIsdmy/f5IGc5r01RjKWNvrbBra6z0xudQM0D6Wf8DeGuPoRlubkLqr7VgWijFucO4kg0mtev9H3RX/ZOubUhg==",
       "requires": {
-        "@aws-sdk/core": "3.966.0",
-        "@aws-sdk/nested-clients": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.965.0.tgz",
-      "integrity": "sha512-jvodoJdMavvg8faN7co58vVJRO5MVep4JFPRzUNCzpJ98BDqWDk/ad045aMJcmxkLzYLS2UAnUmqjJ/tUPNlzQ==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "requires": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-dynamodb": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.966.0.tgz",
-      "integrity": "sha512-bc5HmvegLpMVb6zuh3/roq3i+CEacSK2RIZrHijs90r4lENAWlueZQxJz6ZvazlngfnAi1ZVCXOviPUAWKivSA==",
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.7.tgz",
+      "integrity": "sha512-v+WJASG9yaW8qNM7pNSgH1PBYz5mVTf7gzKPi0NqGjLlaCtPdk6EjM1lmv03egA07iXUw6OToGYfW2w8D3kBrg==",
       "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/util-endpoints": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.965.0.tgz",
-      "integrity": "sha512-WqSCB0XIsGUwZWvrYkuoofi2vzoVHqyeJ2kN+WyoOsxPLTiQSBIoqm/01R/qJvoxwK/gOOF7su9i84Vw2NQQpQ==",
-      "requires": {
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-endpoints": "^3.2.7",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/util-locate-window": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.0.tgz",
-      "integrity": "sha512-9LJFand4bIoOjOF4x3wx0UZYiFZRo4oUauxQSiEX2dVg+5qeBOJSjp2SeWykIE6+6frCZ5wvWm2fGLK8D32aJw==",
-      "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/util-user-agent-browser": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.965.0.tgz",
-      "integrity": "sha512-Xiza/zMntQGpkd2dETQeAK8So1pg5+STTzpcdGWxj5q0jGO5ayjqT/q1Q7BrsX5KIr6PvRkl9/V7lLCv04wGjQ==",
-      "requires": {
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/types": "^4.11.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@aws-sdk/util-user-agent-node": {
-      "version": "3.966.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.966.0.tgz",
-      "integrity": "sha512-vPPe8V0GLj+jVS5EqFz2NUBgWH35favqxliUOvhp8xBdNRkEjiZm5TqitVtFlxS4RrLY3HOndrWbrP5ejbwl1Q==",
-      "requires": {
-        "@aws-sdk/middleware-user-agent": "3.966.0",
-        "@aws-sdk/types": "3.965.0",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.965.0.tgz",
-      "integrity": "sha512-Tcod25/BTupraQwtb+Q+GX8bmEZfxIFjjJ/AvkhUZsZlkPeVluzq1uu3Oeqf145DCdMjzLIN6vab5MrykbDP+g==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "requires": {
-        "@smithy/types": "^4.11.0",
-        "fast-xml-parser": "5.2.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws/lambda-invoke-store": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
-      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="
     },
     "@babel/code-frame": {
       "version": "7.23.5",
@@ -16612,432 +15368,59 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "@smithy/abort-controller": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
-      "integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
-      "requires": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/config-resolver": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
-      "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
-      "requires": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "tslib": "^2.6.2"
-      }
-    },
     "@smithy/core": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.2.tgz",
-      "integrity": "sha512-nc99TseyTwL1bg+T21cyEA5oItNy1XN4aUeyOlXJnvyRW5VSK1oRKRoSM/Iq0KFPuqZMxjBemSZHZCOZbSyBMw==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.0.tgz",
+      "integrity": "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==",
       "requires": {
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-stream": "^4.5.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
-      "integrity": "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA==",
+      "version": "4.4.15",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.15.tgz",
+      "integrity": "sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA==",
       "requires": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
-      "integrity": "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.12.tgz",
+      "integrity": "sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==",
       "requires": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/querystring-builder": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/hash-node": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.7.tgz",
-      "integrity": "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw==",
-      "requires": {
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/invalid-dependency": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
-      "integrity": "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ==",
-      "requires": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/middleware-content-length": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
-      "integrity": "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg==",
-      "requires": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/middleware-endpoint": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.3.tgz",
-      "integrity": "sha512-Zb8R35hjBhp1oFhiaAZ9QhClpPHdEDmNDC2UrrB2fqV0oNDUUPH12ovZHB5xi/Rd+pg/BJHOR1q+SfsieSKPQg==",
-      "requires": {
-        "@smithy/core": "^3.20.2",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/middleware-retry": {
-      "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.19.tgz",
-      "integrity": "sha512-QtisFIjIw2tjMm/ESatjWFVIQb5Xd093z8xhxq/SijLg7Mgo2C2wod47Ib/AHpBLFhwYXPzd7Hp2+JVXfeZyMQ==",
-      "requires": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.4",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
-        "@smithy/uuid": "^1.1.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/middleware-serde": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
-      "integrity": "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w==",
-      "requires": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/middleware-stack": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
-      "integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
-      "requires": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/node-config-provider": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
-      "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
-      "requires": {
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/node-http-handler": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
-      "integrity": "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ==",
+      "version": "4.9.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.12.tgz",
+      "integrity": "sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q==",
       "requires": {
-        "@smithy/abort-controller": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/querystring-builder": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/property-provider": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.7.tgz",
-      "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
-      "requires": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/protocol-http": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
-      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
-      "requires": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/querystring-builder": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
-      "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
-      "requires": {
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/querystring-parser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
-      "integrity": "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w==",
-      "requires": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/service-error-classification": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
-      "integrity": "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA==",
-      "requires": {
-        "@smithy/types": "^4.11.0"
-      }
-    },
-    "@smithy/shared-ini-file-loader": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
-      "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
-      "requires": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/signature-v4": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
-      "integrity": "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.11.tgz",
+      "integrity": "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==",
       "requires": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/smithy-client": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.4.tgz",
-      "integrity": "sha512-rHig+BWjhjlHlah67ryaW9DECYixiJo5pQCTEwsJyarRBAwHMMC3iYz5MXXAHXe64ZAMn1NhTUSTFIu1T6n6jg==",
-      "requires": {
-        "@smithy/core": "^3.20.2",
-        "@smithy/middleware-endpoint": "^4.4.3",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-stream": "^4.5.8",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/types": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.11.0.tgz",
-      "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
-      "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/url-parser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.7.tgz",
-      "integrity": "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg==",
-      "requires": {
-        "@smithy/querystring-parser": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
-      "requires": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
-      "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
-      "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "requires": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
-      "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-defaults-mode-browser": {
-      "version": "4.3.18",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.18.tgz",
-      "integrity": "sha512-Ao1oLH37YmLyHnKdteMp6l4KMCGBeZEAN68YYe00KAaKFijFELDbRQRm3CNplz7bez1HifuBV0l5uR6eVJLhIg==",
-      "requires": {
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.4",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-defaults-mode-node": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.21.tgz",
-      "integrity": "sha512-e21ASJDirE96kKXZLcYcnn4Zt0WGOvMYc1P8EK0gQeQ3I8PbJWqBKx9AUr/YeFpDkpYwEu1RsPe4UXk2+QL7IA==",
-      "requires": {
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/credential-provider-imds": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.4",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-endpoints": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
-      "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
-      "requires": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
-      "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-middleware": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
-      "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
-      "requires": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-retry": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.7.tgz",
-      "integrity": "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg==",
-      "requires": {
-        "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-stream": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.8.tgz",
-      "integrity": "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w==",
-      "requires": {
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-      "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "requires": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/util-waiter": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.7.tgz",
-      "integrity": "sha512-vHJFXi9b7kUEpHWUCY3Twl+9NPOZvQ0SAi+Ewtn48mbiJk4JY9MZmKQjGB4SCvVb9WPiSphZJYY6RIbs+grrzw==",
-      "requires": {
-        "@smithy/abort-controller": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "requires": {
         "tslib": "^2.6.2"
       }
@@ -17171,12 +15554,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
-      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/normalize-package-data": {
@@ -17710,9 +16093,9 @@
       }
     },
     "bowser": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
-      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -18398,8 +16781,8 @@
     "dynamoose": {
       "version": "file:packages/dynamoose",
       "requires": {
-        "@aws-sdk/client-dynamodb": "^3.782.0",
-        "@aws-sdk/util-dynamodb": "^3.782.0",
+        "@aws-sdk/client-dynamodb": "^3.1073.0",
+        "@aws-sdk/util-dynamodb": "^3.996.5",
         "dynamoose-logger": "^4.2.0",
         "dynamoose-utils": "^4.2.0",
         "js-object-utilities": "^2.2.1"
@@ -18814,14 +17197,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-      "requires": {
-        "strnum": "^2.1.0"
-      }
     },
     "fastq": {
       "version": "1.13.0",
@@ -22834,11 +21209,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
-    "strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="
-    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -23166,9 +21536,9 @@
       "optional": true
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "unique-filename": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "doc": "docs"
   },
   "devDependencies": {
-    "@types/node": "^20.10.6",
+    "@types/node": "^20.19.43",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "eslint": "^8.56.0",
     "eslint-plugin-no-only-tests": "^3.1.0",

--- a/packages/dynamoose/lib/ItemRetriever.ts
+++ b/packages/dynamoose/lib/ItemRetriever.ts
@@ -196,7 +196,10 @@ ItemRetriever.prototype.getRequest = async function (this: ItemRetriever): Promi
 		const [key, value] = entry;
 		const filterExpressionIndex = object.FilterExpression.findIndex((item) => item.includes(key));
 		const filterExpression = object.FilterExpression[filterExpressionIndex];
-		if (filterExpression.includes("attribute_exists") || filterExpression.includes("contains")) {
+		// Operators that are legal in a FilterExpression but not in a KeyConditionExpression
+		// must stay where they are, otherwise DynamoDB rejects the request with
+		// "Invalid operator used in KeyConditionExpression".
+		if (filterExpression.includes("attribute_exists") || filterExpression.includes("contains") || filterExpression.includes(" IN (") || filterExpression.includes("<>")) {
 			return;
 		}
 		object.ExpressionAttributeNames[`#${prefix}a`] = value;

--- a/packages/dynamoose/lib/ItemRetriever.ts
+++ b/packages/dynamoose/lib/ItemRetriever.ts
@@ -219,15 +219,53 @@ ItemRetriever.prototype.getRequest = async function (this: ItemRetriever): Promi
 	}
 	if (this.getInternalProperties(internalProperties).internalSettings.typeInformation.type === "query") {
 		const index = utils.array_flatten(Object.values(indexes)).find((index) => index.IndexName === object.IndexName) || indexes.TableIndex;
-		const {hash, range} = index.KeySchema.reduce((res, item) => {
-			res[item.KeyType.toLowerCase()] = item.AttributeName;
+		const {"hash": hashKeys, "range": rangeKeys} = index.KeySchema.reduce((res, item) => {
+			res[item.KeyType.toLowerCase()].push(item.AttributeName);
 			return res;
-		}, {});
+		}, {"hash": [], "range": []} as {[key: string]: string[]});
 
-		moveParameterNames(hash, "qh");
-		if (range) {
-			moveParameterNames(range, "qr");
+		// Enforce DynamoDB's native multi-attribute query rules client-side so a malformed
+		// query fails fast with a clear error instead of emitting a request DynamoDB rejects.
+		// Only multi-attribute keys are validated; single-attribute behavior is unchanged.
+		if (hashKeys.length > 1 || rangeKeys.length > 1) {
+			const KEY_CONDITION_TYPES = new Set(["EQ", "LE", "LT", "GE", "GT", "BETWEEN", "BEGINS_WITH"]);
+			const comparisonChart = await this.getInternalProperties(internalProperties).settings.condition.getInternalProperties(internalProperties).comparisonChart(model);
+			// Every partition-key attribute must be conditioned with equality.
+			for (const attr of hashKeys) {
+				if (comparisonChart[attr]?.type !== "EQ") {
+					throw new CustomError.InvalidParameter(`Query on multi-attribute index "${object.IndexName}" requires an equality condition on every partition key attribute ("${attr}" is missing or not an equality).`);
+				}
+			}
+			// Sort-key attributes must be conditioned left-to-right with no gaps, and a
+			// non-equality condition may only be the last conditioned sort attribute.
+			let ended = false;
+			let sawInequality = false;
+			for (const attr of rangeKeys) {
+				const t = comparisonChart[attr]?.type;
+				const isKeyCondition = typeof t === "string" && KEY_CONDITION_TYPES.has(t);
+				if (!isKeyCondition) {
+					ended = true;
+					continue;
+				}
+				if (ended) {
+					throw new CustomError.InvalidParameter(`Query on multi-attribute index "${object.IndexName}" must condition sort key attributes left-to-right with no gaps ("${attr}" is conditioned after an unconditioned attribute).`);
+				}
+				if (sawInequality) {
+					throw new CustomError.InvalidParameter(`Query on multi-attribute index "${object.IndexName}" allows a non-equality condition only as the last sort key condition ("${attr}" follows one).`);
+				}
+				if (t !== "EQ") {
+					sawInequality = true;
+				}
+			}
 		}
+
+		// Each key attribute needs a UNIQUE placeholder prefix. The first attribute
+		// keeps the legacy "qh"/"qr" prefix so single-attribute queries emit identical
+		// params; later attributes get a numeric suffix (qh1, qr1, ...).
+		hashKeys.forEach((attr, idx) => moveParameterNames(attr, idx === 0 ? "qh" : `qh${idx}`));
+		// Sort attributes move left-to-right. moveParameterNames is a no-op for any
+		// attribute not present as a condition (verified: early-return at L193-195).
+		rangeKeys.forEach((attr, idx) => moveParameterNames(attr, idx === 0 ? "qr" : `qr${idx}`));
 	}
 	if (this.getInternalProperties(internalProperties).settings.consistent) {
 		object.ConsistentRead = this.getInternalProperties(internalProperties).settings.consistent;

--- a/packages/dynamoose/lib/Schema.ts
+++ b/packages/dynamoose/lib/Schema.ts
@@ -279,12 +279,21 @@ export interface TimestampObject {
 	createdAt?: string | string[] | SchemaDefinition;
 	updatedAt?: string | string[] | SchemaDefinition;
 }
+export type IndexDeclaration = Omit<IndexDefinition, "rangeKey"> & {
+	name: string;
+	hashKey: string[];
+	rangeKey?: string[];
+};
 interface SchemaSettings {
 	timestamps?: boolean | TimestampObject;
 	saveUnknown?: boolean | string[];
 	set?: (value: ObjectType) => ObjectType;
 	get?: (value: ObjectType) => ObjectType;
 	validate?: (value: ObjectType) => boolean;
+	indexes?: {
+		global?: IndexDeclaration[];
+		local?: IndexDeclaration[];
+	};
 }
 export enum IndexType {
 	/**
@@ -311,6 +320,11 @@ interface IndexDefinition {
 	 * The range key attribute name for a global secondary index.
 	 */
 	rangeKey?: string;
+	/**
+	 * Multi-attribute partition key for a GLOBAL secondary index (AWS native multi-attribute keys).
+	 * Attribute names in AWS KeySchema order. GSI only; max 4 attributes.
+	 */
+	hashKey?: string[];
 	/**
 	 * Sets the attributes to be projected for the index. `true` projects all attributes, `false` projects only the key attributes, and an array of strings projects the attributes listed.
 	 * @default true
@@ -832,7 +846,7 @@ interface SchemaInternalProperties {
 	getMapSettingValuesForKey: (key: string, settingNames?: string[]) => string[];
 	getMapSettingObject: () => {[key: string]: string};
 	getDefaultMapAttribute: (attribute: string) => string;
-	getIndexAttributes: () => {index: IndexDefinition; attribute: string}[];
+	getIndexAttributes: () => {index: IndexDefinition | IndexDeclaration; attribute: string}[];
 	getTimestampAttributes: () => GetTimestampAttributesType;
 }
 
@@ -1122,8 +1136,8 @@ export class Schema extends InternalPropertiesClass<SchemaInternalProperties> {
 					}
 				}
 			},
-			"getIndexAttributes": (): {index: IndexDefinition; attribute: string}[] => {
-				return this.attributes()
+			"getIndexAttributes": (): {index: IndexDefinition | IndexDeclaration; attribute: string}[] => {
+				const accumulator: {index: IndexDefinition | IndexDeclaration; attribute: string}[] = this.attributes()
 					.map((attribute: string) => ({
 						"index": this.getAttributeSettingValue("index", attribute) as IndexDefinition,
 						attribute
@@ -1142,6 +1156,19 @@ export class Schema extends InternalPropertiesClass<SchemaInternalProperties> {
 						}
 						return accumulator;
 					}, []);
+
+				// Merge top-level multi-attribute index declarations (settings.indexes).
+				// These are not attached to a single attribute, so `attribute` is empty;
+				// the key composition lives entirely in the IndexDeclaration arrays.
+				// Only global indexes are considered: the constructor rejects a local
+				// multi-attribute declaration outright, so none can reach this point.
+				const topLevelGlobal = this.getInternalProperties(internalProperties).settings.indexes?.global;
+				if (topLevelGlobal) {
+					topLevelGlobal.forEach((decl) => {
+						accumulator.push({"index": decl, "attribute": ""});
+					});
+				}
+				return accumulator;
 			},
 			"getTimestampAttributes": () => getTimestampAttributes(settings.timestamps as TimestampObject)
 		});
@@ -1159,6 +1186,41 @@ export class Schema extends InternalPropertiesClass<SchemaInternalProperties> {
 			});
 		};
 		checkAttributeNameDots(this.getInternalProperties(internalProperties).schemaObject);
+
+		const validateMultiAttributeIndexes = (schema: Schema): void => {
+			const settingsIndexes = schema.getInternalProperties(internalProperties).settings.indexes;
+			if (!settingsIndexes) {
+				return;
+			}
+			const declared = new Set(schema.attributes());
+			const entries: {def: IndexDeclaration; type: "global" | "local"}[] = [
+				...(settingsIndexes.global || []).map((def) => ({"def": def, "type": "global" as const})),
+				...(settingsIndexes.local || []).map((def) => ({"def": def, "type": "local" as const}))
+			];
+			for (const {"def": def, "type": indexType} of entries) {
+				if (indexType === "local") {
+					throw new CustomError.InvalidParameter("Multi-attribute keys are only supported on global secondary indexes, not local indexes.");
+				}
+				if (!Array.isArray(def.hashKey) || def.hashKey.length === 0) {
+					throw new CustomError.InvalidParameter(`Multi-attribute index "${def.name}" must declare a non-empty hashKey array.`);
+				}
+				for (const arr of [def.hashKey, def.rangeKey || []]) {
+					if (arr.length > 4) {
+						throw new CustomError.InvalidParameter(`Multi-attribute keys support a maximum of 4 attributes per key, got ${arr.length}.`);
+					}
+					for (const attr of arr) {
+						if (!declared.has(attr)) {
+							throw new CustomError.InvalidParameter(`Attribute "${attr}" is used in a multi-attribute index but is not declared in the schema.`);
+						}
+					}
+				}
+				const overlap = def.hashKey.filter((attr) => (def.rangeKey || []).includes(attr));
+				if (overlap.length > 0) {
+					throw new CustomError.InvalidParameter(`Attribute(s) ${overlap.join(", ")} cannot be in both hashKey and rangeKey of the same index.`);
+				}
+			}
+		};
+		validateMultiAttributeIndexes(this);
 
 		const checkMultipleArraySchemaElements = (key: string): void => {
 			let attributeType: string[] = [];
@@ -1310,8 +1372,19 @@ export class Schema extends InternalPropertiesClass<SchemaInternalProperties> {
 			});
 		}
 
-		utils.array_flatten(await Promise.all([this.getInternalProperties(internalProperties).getIndexAttributes(), this.getIndexRangeKeyAttributes()])).map((obj) => obj.attribute).forEach((index) => {
-			if (AttributeDefinitionsNames.includes(index)) {
+		const indexAttributeEntries = await this.getInternalProperties(internalProperties).getIndexAttributes();
+		// Expand each index entry to its hash-key attribute name(s): a multi-attribute
+		// hashKey array (top-level declarations) or the single attached attribute (legacy).
+		const indexHashKeyAttributes = indexAttributeEntries.flatMap((entry) => {
+			const def = entry.index;
+			if (Array.isArray(def.hashKey) && def.hashKey.length > 0) {
+				return def.hashKey.map((attribute) => ({attribute}));
+			}
+			return [{"attribute": entry.attribute}];
+		});
+
+		utils.array_flatten([indexHashKeyAttributes, await this.getIndexRangeKeyAttributes()]).map((obj) => obj.attribute).forEach((index) => {
+			if (!index || AttributeDefinitionsNames.includes(index)) {
 				return;
 			}
 
@@ -1509,8 +1582,16 @@ Schema.prototype.requiredCheck = async function (this: Schema, key: string, valu
 };
 
 Schema.prototype.getIndexRangeKeyAttributes = async function (this: Schema): Promise<{attribute: string}[]> {
-	const indexes: ({index: IndexDefinition; attribute: string})[] = await this.getInternalProperties(internalProperties).getIndexAttributes();
-	return indexes.map((index) => index.index.rangeKey).filter((a) => Boolean(a)).map((a) => ({"attribute": a}));
+	const indexes: ({index: IndexDefinition | IndexDeclaration; attribute: string})[] = await this.getInternalProperties(internalProperties).getIndexAttributes();
+	return indexes.flatMap((entry) => {
+		const def = entry.index;
+		// Legacy single-string rangeKey
+		if (typeof def.rangeKey === "string") {
+			return [{"attribute": def.rangeKey}];
+		}
+		// New multi-attribute rangeKey array
+		return (def.rangeKey || []).map((attribute) => ({attribute}));
+	});
 };
 export interface TableIndex {
 	KeySchema: ({AttributeName: string; KeyType: "HASH" | "RANGE"})[];
@@ -1536,10 +1617,14 @@ Schema.prototype.getIndexes = async function (this: Schema, model: Model<Item>):
 			dynamoIndexObject.Projection = Array.isArray(indexValue.project) ? {"ProjectionType": "INCLUDE", "NonKeyAttributes": indexValue.project} : {"ProjectionType": "ALL"};
 		}
 		if (isGlobalIndex) {
-			dynamoIndexObject.KeySchema.push({"AttributeName": attributeValue, "KeyType": "HASH"});
-			if (indexValue.rangeKey) {
-				dynamoIndexObject.KeySchema.push({"AttributeName": indexValue.rangeKey, "KeyType": "RANGE"});
-			}
+			// Partition key: multi-attribute array (new) or the single attached attribute (legacy).
+			const hashAttrs = Array.isArray(indexValue.hashKey) && indexValue.hashKey.length > 0 ? indexValue.hashKey : [attributeValue];
+			hashAttrs.forEach((attr) => dynamoIndexObject.KeySchema.push({"AttributeName": attr, "KeyType": "HASH"}));
+
+			// Sort key: multi-attribute array (new) or legacy single string.
+			const rangeAttrs = Array.isArray(indexValue.rangeKey) ? indexValue.rangeKey : typeof indexValue.rangeKey === "string" ? [indexValue.rangeKey] : [];
+			rangeAttrs.forEach((attr) => dynamoIndexObject.KeySchema.push({"AttributeName": attr, "KeyType": "RANGE"}));
+
 			const throughputObject = utils.dynamoose.get_provisioned_throughput(indexValue.throughput ? indexValue : model.getInternalProperties(internalProperties).table().getInternalProperties(internalProperties).options.throughput === "ON_DEMAND" ? {} : model.getInternalProperties(internalProperties).table().getInternalProperties(internalProperties).options);
 			if ("ProvisionedThroughput" in throughputObject) {
 				dynamoIndexObject.ProvisionedThroughput = throughputObject.ProvisionedThroughput;

--- a/packages/dynamoose/lib/utils/find_best_index.ts
+++ b/packages/dynamoose/lib/utils/find_best_index.ts
@@ -7,27 +7,60 @@ interface IndexSpecification {
 	indexName?: string;
 }
 
+const RANGE_TYPES = new Set(["EQ", "LE", "LT", "GE", "GT", "BETWEEN", "BEGINS_WITH"]);
+
 export default function (modelIndexes: ModelIndexes, comparisonChart: ConditionStorageTypeNested): IndexSpecification {
-	const validIndexes = array_flatten(Object.entries(modelIndexes)
+	const annotated = array_flatten(Object.entries(modelIndexes)
 		.map(([key, indexes]) => {
 			indexes = Array.isArray(indexes) ? indexes : [indexes];
 			return indexes.map((index) => {
-				const {hash, range} = index.KeySchema.reduce((res, item) => {
-					res[item.KeyType.toLowerCase()] = item.AttributeName;
+				const {hash, range} = (index.KeySchema as {AttributeName: string; KeyType: string}[]).reduce((res: {hash: string[]; range: string[]}, item) => {
+					res[item.KeyType.toLowerCase()].push(item.AttributeName);
 					return res;
-				}, {});
+				}, {"hash": [], "range": []});
 
-				index._hashKey = hash;
-				index._rangeKey = range;
-
+				index._hashKeys = hash;
+				index._rangeKeys = range;
 				index._tableIndex = key === "TableIndex";
+
+				// All partition attributes must be conditioned with EQ.
+				const allHashEq = hash.length > 0 && hash.every((attr) => comparisonChart[attr]?.type === "EQ");
+				index._usable = allHashEq;
+
+				// Longest left-to-right sort-key prefix that is conditioned (equality until an
+				// inequality, which must be the last conditioned sort attr).
+				let prefix = 0;
+				let sawInequality = false;
+				for (const attr of range) {
+					const t = comparisonChart[attr]?.type;
+					if (!t || !RANGE_TYPES.has(t)) {
+						break;
+					}
+					if (t === "EQ") {
+						if (sawInequality) {
+							break;
+						}
+						prefix++;
+					} else {
+						if (sawInequality) {
+							break;
+						}
+						prefix++;
+						sawInequality = true;
+					}
+				}
+				index._sortPrefix = prefix;
 
 				return index;
 			});
-		}))
-		.filter((index) => comparisonChart[index._hashKey]?.type === "EQ");
+		}));
 
-	const index = validIndexes.find((index) => comparisonChart[index._rangeKey]) || validIndexes.find((index) => index._tableIndex) || validIndexes[0];
+	const usable = annotated.filter((index) => index._usable);
+	// Rank by the longest left-to-right sort-key prefix conditioned. On a tie, prefer the table
+	// index (matching legacy selection), then fall back to insertion order.
+	const bestPrefix = usable.reduce((max, index) => Math.max(max, index._sortPrefix), 0);
+	const topUsable = usable.filter((index) => index._sortPrefix === bestPrefix);
+	const chosen = topUsable.find((index) => index._tableIndex) || topUsable[0];
 
-	return {"tableIndex": index?._tableIndex ?? false, "indexName": index?.IndexName ?? null};
+	return {"tableIndex": chosen?._tableIndex ?? false, "indexName": chosen?.IndexName ?? null};
 }

--- a/packages/dynamoose/lib/utils/merge_objects.ts
+++ b/packages/dynamoose/lib/utils/merge_objects.ts
@@ -47,7 +47,7 @@ const main = (settings: MergeObjectsSettings = {"combineMethod": MergeObjectsCom
 					if (settings.combineMethod === MergeObjectsCombineMethod.ArrayMergeNewArray) {
 						returnObject[key] = [returnObject[key], arg[key]];
 					} else if (typeof returnObject[key] === "number") {
-						returnObject[key] += arg[key];
+						returnObject[key] += arg[key] as number;
 					} else {
 						returnObject[key] = arg[key];
 					}

--- a/packages/dynamoose/package.json
+++ b/packages/dynamoose/package.json
@@ -28,8 +28,8 @@
     "test:types": "tsc --project test/types/tsconfig.json"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.782.0",
-    "@aws-sdk/util-dynamodb": "^3.782.0",
+    "@aws-sdk/client-dynamodb": "^3.1073.0",
+    "@aws-sdk/util-dynamodb": "^3.996.5",
     "dynamoose-utils": "^4.2.0",
     "js-object-utilities": "^2.2.1"
   },

--- a/packages/dynamoose/test/Query.js
+++ b/packages/dynamoose/test/Query.js
@@ -1916,6 +1916,54 @@ describe("Query", () => {
 		});
 	});
 
+	describe("Illegal-in-key operator promotion (IN/NE on a key attribute stays FilterExpression)", () => {
+		let SingleRangeModel, MultiRangeModel;
+
+		beforeEach(() => {
+			// Single-attribute range key: filtering the sort key with an operator that
+			// is illegal in a KeyConditionExpression must remain a FilterExpression.
+			SingleRangeModel = dynamoose.model("SingleRangeCat", {"id": String, "name": {"type": String, "index": {"type": "global", "rangeKey": "age"}}, "age": Number});
+			new dynamoose.Table("SingleRangeCat", [SingleRangeModel]);
+
+			// Multi-attribute range key [round, bracket]: IN on the leading sort attribute
+			// must remain a FilterExpression (validation accepts it; promotion must not move it).
+			const schema = new dynamoose.Schema({
+				"matchId": {"type": String, "hashKey": true},
+				"tournamentId": String, "region": String, "round": String, "bracket": String
+			}, {
+				"indexes": {"global": [
+					{"name": "TRI2", "hashKey": ["tournamentId", "region"], "rangeKey": ["round", "bracket"]}
+				]}
+			});
+			MultiRangeModel = dynamoose.model("MultiRangeMatch", schema);
+			new dynamoose.Table("MultiRangeMatch", [MultiRangeModel]);
+		});
+
+		it("single-attr rangeKey: .filter(sortKey).in(...) stays FilterExpression", async () => {
+			queryPromiseResolver = () => ({"Items": []});
+			await SingleRangeModel.query("name").eq("Charlie").filter("age").in([10, 20]).exec();
+			expect(queryParams.FilterExpression).toMatch(/IN \(/);
+			expect(queryParams.KeyConditionExpression).toEqual("#qha = :qhv");
+		});
+
+		it("multi-attr rangeKey: .filter(leading sortKey).in(...) stays FilterExpression", async () => {
+			queryPromiseResolver = () => ({"Items": []});
+			await MultiRangeModel.query({"tournamentId": "T1", "region": "NA"}).filter("round").in(["QF", "SF"]).using("TRI2").exec();
+			expect(queryParams.FilterExpression).toMatch(/IN \(/);
+			expect(queryParams.KeyConditionExpression).not.toMatch(/IN/);
+			// round is rangeKey[0] (prefix "qr" -> "#qra"); it must not be promoted.
+			expect(queryParams.KeyConditionExpression).not.toMatch(/#qra/);
+		});
+
+		it("single-attr rangeKey: .filter(sortKey).not().eq(...) stays FilterExpression", async () => {
+			queryPromiseResolver = () => ({"Items": []});
+			await SingleRangeModel.query("name").eq("Charlie").filter("age").not().eq(5).exec();
+			// NE renders as "<>" in the emitted expression.
+			expect(queryParams.FilterExpression).toMatch(/<>/);
+			expect(queryParams.KeyConditionExpression).toEqual("#qha = :qhv");
+		});
+	});
+
 	describe("query.using", () => {
 		it("Should be a function", () => {
 			expect(Model.query().using).toBeInstanceOf(Function);

--- a/packages/dynamoose/test/Query.js
+++ b/packages/dynamoose/test/Query.js
@@ -1827,6 +1827,95 @@ describe("Query", () => {
 		});
 	});
 
+	describe("query.multi-attribute partition keys", () => {
+		it("should build a KeyConditionExpression covering all multi-attribute partition keys", async () => {
+			queryPromiseResolver = () => ({"Items": [], "Count": 0});
+			const schema = new dynamoose.Schema({
+				"matchId": {"type": String, "hashKey": true},
+				"tournamentId": String, "region": String, "round": String
+			}, {
+				"indexes": {"global": [{"name": "TRI", "hashKey": ["tournamentId", "region"], "rangeKey": ["round"]}]}
+			});
+			const Match = dynamoose.model("MatchMultiAttrPK", schema);
+			new dynamoose.Table("MatchMultiAttrPK", [Match]);
+			await Match.query({"tournamentId": "T1", "region": "NA"}).where("round").eq("QF").using("TRI").exec();
+			const params = queryParams;
+			expect(params.IndexName).toBe("TRI");
+			// Attribute names live in ExpressionAttributeNames; KeyConditionExpression holds placeholders.
+			const names = params.ExpressionAttributeNames;
+			const placeholderFor = (attr) => Object.keys(names).find((key) => names[key] === attr);
+			["tournamentId", "region", "round"].forEach((attr) => {
+				const placeholder = placeholderFor(attr);
+				expect(placeholder).toBeDefined();
+				expect(params.KeyConditionExpression).toContain(placeholder);
+			});
+		});
+
+		it("should build a KeyConditionExpression for a single-PK multi-attribute sort index with beginsWith", async () => {
+			queryPromiseResolver = () => ({"Items": [], "Count": 0});
+			const schema = new dynamoose.Schema({
+				"matchId": {"type": String, "hashKey": true},
+				"player1Id": String, "matchDate": String, "round": String
+			}, {
+				"indexes": {"global": [{"name": "PlayerMatchHistoryIndex", "hashKey": ["player1Id"], "rangeKey": ["matchDate", "round"]}]}
+			});
+			const Match = dynamoose.model("MatchPlayerHistory", schema);
+			new dynamoose.Table("MatchPlayerHistory", [Match]);
+			await Match.query({"player1Id": "p9"}).where("matchDate").beginsWith("2026-").using("PlayerMatchHistoryIndex").exec();
+			const params = queryParams;
+			expect(params.IndexName).toBe("PlayerMatchHistoryIndex");
+			const names = params.ExpressionAttributeNames;
+			const placeholderFor = (attr) => Object.keys(names).find((key) => names[key] === attr);
+			const playerPlaceholder = placeholderFor("player1Id");
+			const datePlaceholder = placeholderFor("matchDate");
+			expect(playerPlaceholder).toBeDefined();
+			expect(datePlaceholder).toBeDefined();
+			// PK is an equality; the sort condition is a begins_with on the first sort attr.
+			expect(params.KeyConditionExpression).toContain(playerPlaceholder);
+			expect(params.KeyConditionExpression).toContain(`begins_with (${datePlaceholder}`);
+		});
+	});
+
+	describe("Native multi-attribute query rule enforcement", () => {
+		let Match;
+		beforeEach(() => {
+			const schema = new dynamoose.Schema({
+				"matchId": {"type": String, "hashKey": true},
+				"tournamentId": String, "region": String, "round": String, "bracket": String
+			}, {
+				"indexes": {"global": [
+					{"name": "TRI", "hashKey": ["tournamentId", "region"], "rangeKey": ["round", "bracket", "matchId"]}
+				]}
+			});
+			Match = dynamoose.model("MultiAttrEnforceMatch", schema);
+			new dynamoose.Table("MultiAttrEnforceMatch", [Match]);
+		});
+
+		it("rejects a query missing a partition-key attribute (not all PK equality)", () => {
+			return expect(
+				Match.query({"tournamentId": "T1"}).where("round").eq("QF").using("TRI").exec()
+			).rejects.toThrow(/partition key/i);
+		});
+
+		it("rejects a query that skips a sort-key attribute (gap)", () => {
+			return expect(
+				Match.query({"tournamentId": "T1", "region": "NA"}).where("round").eq("QF").where("matchId").eq("m1").using("TRI").exec()
+			).rejects.toThrow(/left-to-right|gap/i);
+		});
+
+		it("rejects a non-equality sort condition that is not last", () => {
+			return expect(
+				Match.query({"tournamentId": "T1", "region": "NA"}).where("round").gt("QF").where("bracket").eq("upper").using("TRI").exec()
+			).rejects.toThrow(/last sort key/i);
+		});
+
+		it("allows a valid query with an inequality as the last sort condition", async () => {
+			queryPromiseResolver = () => ({"Items": [], "Count": 0});
+			// Should NOT throw; build + (mocked) execute succeed.
+			await Match.query({"tournamentId": "T1", "region": "NA"}).where("round").eq("QF").where("bracket").beginsWith("up").using("TRI").exec();
+		});
+	});
+
 	describe("query.using", () => {
 		it("Should be a function", () => {
 			expect(Model.query().using).toBeInstanceOf(Function);

--- a/packages/dynamoose/test/Schema.js
+++ b/packages/dynamoose/test/Schema.js
@@ -954,6 +954,77 @@ describe("Schema", () => {
 						}
 					]
 				}
+			},
+			{
+				"name": "Should return correct result with native multi-attribute GSI keys (Number sort attr)",
+				"settings": {"indexes": {"global": [{"name": "TournamentRegionIndex", "hashKey": ["tournamentId", "region"], "rangeKey": ["round", "seq"]}]}},
+				"input": {"matchId": String, "tournamentId": String, "region": String, "round": String, "seq": Number},
+				"output": {
+					"AttributeDefinitions": [
+						{"AttributeName": "matchId", "AttributeType": "S"},
+						{"AttributeName": "tournamentId", "AttributeType": "S"},
+						{"AttributeName": "region", "AttributeType": "S"},
+						{"AttributeName": "round", "AttributeType": "S"},
+						{"AttributeName": "seq", "AttributeType": "N"}
+					],
+					"KeySchema": [{"AttributeName": "matchId", "KeyType": "HASH"}],
+					"GlobalSecondaryIndexes": [{
+						"IndexName": "TournamentRegionIndex",
+						"KeySchema": [
+							{"AttributeName": "tournamentId", "KeyType": "HASH"},
+							{"AttributeName": "region", "KeyType": "HASH"},
+							{"AttributeName": "round", "KeyType": "RANGE"},
+							{"AttributeName": "seq", "KeyType": "RANGE"}
+						],
+						"Projection": {"ProjectionType": "ALL"}
+					}]
+				}
+			},
+			{
+				"name": "Should return correct result with two native multi-attribute GSIs",
+				"settings": {"indexes": {"global": [
+					{"name": "TournamentRegionIndex", "hashKey": ["tournamentId", "region"], "rangeKey": ["round", "bracket", "matchId"]},
+					{"name": "PlayerMatchHistoryIndex", "hashKey": ["player1Id"], "rangeKey": ["matchDate", "round"]}
+				]}},
+				"input": {
+					"matchId": {"type": String, "hashKey": true},
+					"tournamentId": String, "region": String, "round": String, "bracket": String,
+					"player1Id": String, "matchDate": String
+				},
+				"output": {
+					"AttributeDefinitions": [
+						{"AttributeName": "matchId", "AttributeType": "S"},
+						{"AttributeName": "tournamentId", "AttributeType": "S"},
+						{"AttributeName": "region", "AttributeType": "S"},
+						{"AttributeName": "player1Id", "AttributeType": "S"},
+						{"AttributeName": "round", "AttributeType": "S"},
+						{"AttributeName": "bracket", "AttributeType": "S"},
+						{"AttributeName": "matchDate", "AttributeType": "S"}
+					],
+					"KeySchema": [{"AttributeName": "matchId", "KeyType": "HASH"}],
+					"GlobalSecondaryIndexes": [
+						{
+							"IndexName": "TournamentRegionIndex",
+							"KeySchema": [
+								{"AttributeName": "tournamentId", "KeyType": "HASH"},
+								{"AttributeName": "region", "KeyType": "HASH"},
+								{"AttributeName": "round", "KeyType": "RANGE"},
+								{"AttributeName": "bracket", "KeyType": "RANGE"},
+								{"AttributeName": "matchId", "KeyType": "RANGE"}
+							],
+							"Projection": {"ProjectionType": "ALL"}
+						},
+						{
+							"IndexName": "PlayerMatchHistoryIndex",
+							"KeySchema": [
+								{"AttributeName": "player1Id", "KeyType": "HASH"},
+								{"AttributeName": "matchDate", "KeyType": "RANGE"},
+								{"AttributeName": "round", "KeyType": "RANGE"}
+							],
+							"Projection": {"ProjectionType": "ALL"}
+						}
+					]
+				}
 			}
 		];
 
@@ -961,7 +1032,7 @@ describe("Schema", () => {
 			it(test.name, async () => {
 				const table = {"getInternalProperties": () => ({"options": {"throughput": "ON_DEMAND"}})};
 				const model = {"getInternalProperties": () => ({"table": () => table})};
-				expect(await new dynamoose.Schema(test.input).getCreateTableAttributeParams(model)).toEqual(test.output);
+				expect(await new dynamoose.Schema(test.input, test.settings).getCreateTableAttributeParams(model)).toEqual(test.output);
 			});
 		});
 	});
@@ -1478,6 +1549,59 @@ describe("Schema", () => {
 			it(`Should return ${JSON.stringify(test.output)} for ${JSON.stringify(test.input)}`, () => {
 				expect(new dynamoose.Schema({"id": String}).getInternalProperties(internalProperties).getTimestampAttributes(test.input)).toEqual(test.output);
 			});
+		});
+	});
+
+	describe("indexes (multi-attribute)", () => {
+		// Multi-attribute index declarations are validated synchronously in the Schema
+		// constructor, so these assertions check that constructing the Schema throws.
+
+		it("should reject multi-attribute arrays on a local index", () => {
+			expect(() => new dynamoose.Schema({"id": String, "a": String, "b": String}, {
+				"indexes": {"local": [{"name": "li", "hashKey": ["id"], "rangeKey": ["a", "b"]}]}
+			})).toThrow(/local/i);
+		});
+
+		it("should reject more than 4 attributes in a key array", () => {
+			expect(() => new dynamoose.Schema({"id": String, "a": String, "b": String, "c": String, "d": String, "e": String}, {
+				"indexes": {"global": [{"name": "gi", "hashKey": ["a", "b", "c", "d", "e"]}]}
+			})).toThrow(/4/i);
+		});
+
+		it("should reject an array member that is not a declared attribute", () => {
+			expect(() => new dynamoose.Schema({"id": String, "a": String}, {
+				"indexes": {"global": [{"name": "gi", "hashKey": ["a", "nope"]}]}
+			})).toThrow(/nope/);
+		});
+
+		it("should reject an attribute in both hashKey and rangeKey of one index", () => {
+			expect(() => new dynamoose.Schema({"id": String, "a": String}, {
+				"indexes": {"global": [{"name": "gi", "hashKey": ["a"], "rangeKey": ["a"]}]}
+			})).toThrow(/hashKey.*rangeKey|rangeKey.*hashKey/);
+		});
+
+		it("should reject a global index with an empty hashKey array", () => {
+			expect(() => new dynamoose.Schema({"id": String, "a": String}, {
+				"indexes": {"global": [{"name": "gi", "hashKey": []}]}
+			})).toThrow(/hashKey/);
+		});
+
+		it("should construct a valid multi-attribute global index without error", () => {
+			expect(() => new dynamoose.Schema({"id": String, "a": String, "b": String, "c": String}, {
+				"indexes": {"global": [{"name": "gi", "hashKey": ["a", "b"], "rangeKey": ["c"]}]}
+			})).not.toThrow();
+		});
+
+		it("should construct a valid multi-attribute global index declared without a rangeKey", () => {
+			expect(() => new dynamoose.Schema({"id": String, "a": String, "b": String}, {
+				"indexes": {"global": [{"name": "gi", "hashKey": ["a", "b"]}]}
+			})).not.toThrow();
+		});
+
+		it("should reject a local index declared without a global index alongside it", () => {
+			expect(() => new dynamoose.Schema({"id": String, "a": String, "b": String}, {
+				"indexes": {"local": [{"name": "li", "hashKey": ["a"], "rangeKey": ["b"]}]}
+			})).toThrow(/local/i);
 		});
 	});
 });

--- a/packages/dynamoose/test/utils/dynamoose/index_changes.js
+++ b/packages/dynamoose/test/utils/dynamoose/index_changes.js
@@ -340,4 +340,54 @@ describe("utils.dynamoose.index_changes", () => {
 		const table = new dynamoose.Table("Table", [Model], {"create": false, "waitForActive": false, "update": false, "throughput": "ON_DEMAND"});
 		expect(await utils.dynamoose.index_changes(table, test.input)).toEqual(test.output);
 	});
+
+	it("Should not recreate a multi-attribute GSI when its KeySchema is unchanged", async () => {
+		const schema = new dynamoose.Schema({
+			"matchId": {"type": String, "hashKey": true},
+			"tournamentId": String, "region": String, "round": String
+		}, {
+			"indexes": {"global": [{"name": "TRI", "hashKey": ["tournamentId", "region"], "rangeKey": ["round"]}]}
+		});
+		const Model = dynamoose.model("MatchIdxModelA", schema);
+		const table = new dynamoose.Table("MatchIdxTableA", [Model], {"create": false, "waitForActive": false, "update": false});
+		const input = [{
+			"IndexName": "TRI",
+			"KeySchema": [
+				{"AttributeName": "tournamentId", "KeyType": "HASH"},
+				{"AttributeName": "region", "KeyType": "HASH"},
+				{"AttributeName": "round", "KeyType": "RANGE"}
+			],
+			"Projection": {"ProjectionType": "ALL"},
+			"ProvisionedThroughput": {"ReadCapacityUnits": 1, "WriteCapacityUnits": 1}
+		}];
+		expect(await utils.dynamoose.index_changes(table, input)).toEqual([]);
+	});
+
+	it("Should detect a change when a multi-attribute GSI KeySchema differs", async () => {
+		const schema = new dynamoose.Schema({
+			"matchId": {"type": String, "hashKey": true},
+			"tournamentId": String, "region": String, "round": String
+		}, {
+			"indexes": {"global": [{"name": "TRI", "hashKey": ["tournamentId", "region"], "rangeKey": ["round"]}]}
+		});
+		const Model = dynamoose.model("MatchIdxModelB", schema);
+		const table = new dynamoose.Table("MatchIdxTableB", [Model], {"create": false, "waitForActive": false, "update": false});
+		// Existing index drops the second partition attribute (region) — a genuine multi-element difference.
+		const input = [{
+			"IndexName": "TRI",
+			"KeySchema": [
+				{"AttributeName": "tournamentId", "KeyType": "HASH"},
+				{"AttributeName": "round", "KeyType": "RANGE"}
+			],
+			"Projection": {"ProjectionType": "ALL"},
+			"ProvisionedThroughput": {"ReadCapacityUnits": 1, "WriteCapacityUnits": 1}
+		}];
+		const result = await utils.dynamoose.index_changes(table, input);
+		// The multi-element difference IS detected: the stale index is marked for deletion.
+		// Production behavior (index_changes.ts L60): a same-named index already present in
+		// existingIndexes is excluded from the "add" list, so it is only deleted here and
+		// recreated on a later reconciliation pass — the emitted diff is delete-only.
+		expect(result).toContainEqual({"name": "TRI", "type": "delete"});
+		expect(result.some((c) => c.type === "add" && c.spec.IndexName === "TRI")).toBe(false);
+	});
 });

--- a/packages/dynamoose/test/utils/find_best_index.js
+++ b/packages/dynamoose/test/utils/find_best_index.js
@@ -219,4 +219,70 @@ describe("utils.find_best_index", () => {
 			"attr3": {"type": "EQ"}
 		})).toStrictEqual({"tableIndex": false, "indexName": null});
 	});
+
+	describe("find_best_index (multi-attribute)", () => {
+		it("selects an index only when ALL multi-attribute partition keys are EQ", () => {
+			const indexes = {
+				"GlobalSecondaryIndexes": [{
+					"IndexName": "TRI",
+					"KeySchema": [
+						{"AttributeName": "tournamentId", "KeyType": "HASH"},
+						{"AttributeName": "region", "KeyType": "HASH"},
+						{"AttributeName": "round", "KeyType": "RANGE"}
+					]
+				}]
+			};
+			// Only tournamentId is conditioned -> must NOT pick TRI (region missing)
+			const partial = {"tournamentId": {"type": "EQ"}};
+			expect(find_best_index(indexes, partial).indexName).toBeNull();
+
+			const full = {"tournamentId": {"type": "EQ"}, "region": {"type": "EQ"}};
+			expect(find_best_index(indexes, full).indexName).toBe("TRI");
+		});
+
+		it("prefers the index with the longest left-to-right sort-key prefix conditioned", () => {
+			const indexes = {
+				"GlobalSecondaryIndexes": [
+					{"IndexName": "A", "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}, {"AttributeName": "sk1", "KeyType": "RANGE"}]},
+					{"IndexName": "B", "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}, {"AttributeName": "sk1", "KeyType": "RANGE"}, {"AttributeName": "sk2", "KeyType": "RANGE"}]}
+				]
+			};
+			const chart = {"pk": {"type": "EQ"}, "sk1": {"type": "EQ"}, "sk2": {"type": "EQ"}};
+			expect(find_best_index(indexes, chart).indexName).toBe("B");
+		});
+
+		it("treats an inequality on a sort attr as a valid last condition but stops the prefix there", () => {
+			const indexes = {"GlobalSecondaryIndexes": [
+				{"IndexName": "C", "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}, {"AttributeName": "sk1", "KeyType": "RANGE"}, {"AttributeName": "sk2", "KeyType": "RANGE"}]}
+			]};
+			// sk1 EQ, sk2 GT -> prefix length 2 (sk1 eq, sk2 inequality-last)
+			const chart = {"pk": {"type": "EQ"}, "sk1": {"type": "EQ"}, "sk2": {"type": "GT"}};
+			expect(find_best_index(indexes, chart).indexName).toBe("C");
+		});
+
+		it("does not over-count a second consecutive sort-key inequality", () => {
+			// A's prefix is 1 (sk1 inequality). B's prefix is also 1 once the over-count is
+			// fixed (sk1 inequality ends the prefix; sk2 must not extend it). Before the fix,
+			// B over-counted to 2 and was wrongly selected; after the fix it ties A and the
+			// first-inserted usable index (A) is chosen.
+			const indexes = {"GlobalSecondaryIndexes": [
+				{"IndexName": "A", "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}, {"AttributeName": "sk1", "KeyType": "RANGE"}]},
+				{"IndexName": "B", "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}, {"AttributeName": "sk1", "KeyType": "RANGE"}, {"AttributeName": "sk2", "KeyType": "RANGE"}]}
+			]};
+			const chart = {"pk": {"type": "EQ"}, "sk1": {"type": "GT"}, "sk2": {"type": "GT"}};
+			expect(find_best_index(indexes, chart).indexName).toBe("A");
+		});
+
+		it("does not extend the prefix when an equality follows a sort-key inequality", () => {
+			// sk1 inequality (GT) sets sawInequality; a following sk2 EQ must break the
+			// prefix loop (an inequality must be the last conditioned sort attr) instead of
+			// wrongly counting sk2 and over-selecting index B.
+			const indexes = {"GlobalSecondaryIndexes": [
+				{"IndexName": "A", "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}, {"AttributeName": "sk1", "KeyType": "RANGE"}]},
+				{"IndexName": "B", "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}, {"AttributeName": "sk1", "KeyType": "RANGE"}, {"AttributeName": "sk2", "KeyType": "RANGE"}]}
+			]};
+			const chart = {"pk": {"type": "EQ"}, "sk1": {"type": "GT"}, "sk2": {"type": "EQ"}};
+			expect(find_best_index(indexes, chart).indexName).toBe("A");
+		});
+	});
 });


### PR DESCRIPTION
### Summary

Adds native support for AWS [multi-attribute composite GSI keys](https://aws.amazon.com/about-aws/whats-new/2025/11/amazon-dynamodb-multi-attribute-composite-keys-global-secondary-indexes/) — up to 4 attributes per partition key and 4 per sort key (8 total per index) — emitting a native multi-element `KeySchema` with preserved S/N/B types instead of a synthetic `Combine` string.

- Declared via `settings.indexes.global[]` with `{ name, hashKey[], rangeKey[] }`.
- Validates GSI-only usage, max 4 key attributes per key, all declared attributes exist, and no PK/SK overlap.
- Index selection picks the longest left-to-right sort-key prefix.
- Enforces query rules client-side: all partition-key equality, no sort-key gaps, inequality last.
- Backward compatible with legacy single-attribute indexes.

> Note: this PR also raises the declared AWS SDK floor (`@aws-sdk/client-dynamodb` `^3.782.0` -> `^3.1073.0`, `@aws-sdk/util-dynamodb` `^3.782.0` -> `^3.996.5`). Multi-element GSI `KeySchema` needs a newer SDK than the old floor guaranteed. This stays within the existing `^3` caret range — it is not a major bump.

### Code sample
#### Schema
```js
const MatchSchema = new dynamoose.Schema(
  {
    matchId:      { type: String, hashKey: true },
    tournamentId: String,
    region:       String,
    round:        Number,   // stays Number in the index — sorts numerically, no zero-padding
    bracket:      String,
  },
  {
    indexes: {
      global: [
        {
          name: "TournamentRegionIndex",
          hashKey:  ["tournamentId", "region"],
          rangeKey: ["round", "bracket", "matchId"],
        },
      ],
    },
  },
);
```

#### Model
```js
// Best-matching index is selected automatically by the longest
// left-to-right sort-key prefix used in the query conditions.
await Match.query({ tournamentId: "T1", region: "NA" })
  .where("round").eq(4)
  .where("bracket").eq("A")
  .using("TournamentRegionIndex")
  .exec();
```

#### General
```
// N/A
```

### Before / After — what DynamoDB sees

**Before — `Combine` type (one synthetic string per key).** Multiple attributes are concatenated into a single string attribute, so the GSI has one `HASH` and one `RANGE`, both `S`. Numbers must be zero-padded to sort correctly, and you cannot target individual members of the composite key in a query.

```jsonc
// describeTable — Combine approach
{
  "AttributeDefinitions": [
    { "AttributeName": "matchId", "AttributeType": "S" },
    { "AttributeName": "pk",      "AttributeType": "S" },  // tournamentId#region
    { "AttributeName": "sk",      "AttributeType": "S" }   // 00000004#A#m_123
  ],
  "GlobalSecondaryIndexes": [{
    "IndexName": "TournamentRegionIndex",
    "KeySchema": [
      { "AttributeName": "pk", "KeyType": "HASH"  },
      { "AttributeName": "sk", "KeyType": "RANGE" }
    ]
  }]
}
```

**After — native multi-attribute keys.** Each key attribute stays a first-class column with its declared type. `round` remains `N`, so DynamoDB sorts it numerically with no padding, and `Binary` keys stay binary.

```jsonc
// describeTable — native multi-attribute approach
{
  "AttributeDefinitions": [
    { "AttributeName": "matchId",      "AttributeType": "S" },
    { "AttributeName": "tournamentId", "AttributeType": "S" },
    { "AttributeName": "region",       "AttributeType": "S" },
    { "AttributeName": "round",        "AttributeType": "N" },  // preserved
    { "AttributeName": "bracket",      "AttributeType": "S" }
  ],
  "GlobalSecondaryIndexes": [{
    "IndexName": "TournamentRegionIndex",
    "KeySchema": [
      { "AttributeName": "tournamentId", "KeyType": "HASH"  },
      { "AttributeName": "region",       "KeyType": "HASH"  },
      { "AttributeName": "round",        "KeyType": "RANGE" },
      { "AttributeName": "bracket",      "KeyType": "RANGE" },
      { "AttributeName": "matchId",      "KeyType": "RANGE" }
    ]
  }]
}
```

What this unlocks vs the `Combine` workaround:

- No synthetic string column — each key member is a real, individually-queryable attribute.
- Type fidelity: `Number` sorts numerically (no zero-padding), `Binary` stays binary, no stringification.
- Up to 4 partition-key + 4 sort-key attributes per GSI (8 total), declared in `KeySchema` order.
- Client-side query validation: all partition keys must be equality, sort keys matched left-to-right with no gaps, inequality allowed only on the last condition.


### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
#----


### Other information:

This PR now targets `main` directly and is **no longer stacked**. It was previously built on top of `fix/model-item-bugs`; the branch has been rebuilt from the current `main` so the diff contains only the multi-attribute GSI key work.

It carries 4 commits:

| commit | purpose |
| --- | --- |
| `fix(utils): narrow the numeric addition cast in merge_objects` | Unblocks the build — see note below |
| `feat(schema): native multi-attribute composite GSI keys` | The feature |
| `fix(ItemRetriever): keep illegal-in-key operators as FilterExpression` | `IN` / `<>` must not be promoted into a `KeyConditionExpression` |
| `build(deps): raise the AWS SDK floor for multi-attribute GSI keys` | Dependency floor + lockfile |

**One overlap to flag:** `main` does not currently compile. `lib/utils/merge_objects.ts:50` fails with `Operator '+=' cannot be applied to types 'number' and 'T'`. The first commit here fixes that one line, and PR #1783 contains the identical fix. Whichever of the two merges second should drop that commit. Happy to split it into its own PR if you would rather it land independently of either feature.

### Type (select 1):
- [ ] Bug fix
- [x] Feature implementation
- [x] Documentation improvement
- [x] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [] I'm not sure
<!-- The public Dynamoose API is unchanged and legacy single-attribute indexes stay backward compatible. The AWS SDK change only raises the declared floor within the existing ^3 caret range, so it is not a major dependency bump. -->


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No
<!-- No longer blocked: this branch is rebased directly onto `main` and all CI checks pass. -->


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No
<!-- Full suite run: 2430 tests, 0 failures, on Node 20/22/24 locally and all 11 CI Node versions. Coveralls reports 100.0% (no decrease). -->


### Other:
- [x] I have read through and followed the Contributing Guidelines
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above

---

This pull request description was drafted by an AI agent (Claude Code, Opus 5). The human contributor directed the work, made the design decisions, reviewed all changes, ran the tests, and approved this submission.
